### PR TITLE
Add subscription listener

### DIFF
--- a/src/docs/asciidoc/usage.adoc
+++ b/src/docs/asciidoc/usage.adoc
@@ -26,6 +26,26 @@ include::{test-examples}/Api.java[tag=connection-settings]
 <1> Use the `guest` user by default
 <2> Use the `admin` user for this connection
 
+=== Subscription Listener
+
+The client provides a `SubscriptionListener` interface callback to add behavior before a subscription is created.
+This callback is meant for stream consumers: it can be used to dynamically set the offset the consumer attaches to in the stream.
+It is called when the consumer is first created and when the client has to re-subscribe (e.g. after a disconnection).
+
+It is possible to use the callback to get the last processed offset from an external store.
+The following code snippet shows how this can be done (note the interaction with the external store is not detailed):
+
+.Using the subscription listener to attach to a stream
+[source,java,indent=0]
+--------
+include::{test-examples}/Api.java[tag=subscription-listener]
+--------
+<1> Set subscription listener
+<2> Get offset from external store
+<3> Set offset to use for the subscription
+<4> Get the message offset
+<5> Store the offset in the external store after processing
+
 === Metrics Collection
 
 The library provides the {javadoc-url}/com/rabbitmq/client/amqp/metrics/MetricsCollector.html[`MetricsCollector`] abstraction to collect metrics.

--- a/src/main/java/com/rabbitmq/client/amqp/ConsumerBuilder.java
+++ b/src/main/java/com/rabbitmq/client/amqp/ConsumerBuilder.java
@@ -190,6 +190,9 @@ public interface ConsumerBuilder {
      * <p>It is called before the link is created but also every time it recovers, e.g. after a
      * connection failure.
      *
+     * <p>Configuration set with {@link Context#streamOptions()} overrides the one set with {@link
+     * ConsumerBuilder#stream()}.
+     *
      * @param context subscription context
      */
     void preSubscribe(Context context);

--- a/src/main/java/com/rabbitmq/client/amqp/ConsumerBuilder.java
+++ b/src/main/java/com/rabbitmq/client/amqp/ConsumerBuilder.java
@@ -74,6 +74,15 @@ public interface ConsumerBuilder {
    */
   StreamOptions stream();
 
+  /**
+   * Set a listener to customize the subscription before the consumer is created (or recovered).
+   *
+   * <p>This callback is available for stream consumers.
+   *
+   * @param subscriptionListener subscription listener
+   * @return this builder instance
+   * @see SubscriptionListener
+   */
   ConsumerBuilder subscriptionListener(SubscriptionListener subscriptionListener);
 
   /**
@@ -167,12 +176,36 @@ public interface ConsumerBuilder {
     NEXT
   }
 
+  /**
+   * Callback to modify a consumer subscription before the link creation.
+   *
+   * <p>This allows looking up the last processed offset for a stream consumer and attaching to this
+   * offset.
+   */
   interface SubscriptionListener {
 
+    /**
+     * Pre-subscription callback.
+     *
+     * <p>It is called before the link is created but also every time it recovers, e.g. after a
+     * connection failure.
+     *
+     * @param context subscription context
+     */
     void preSubscribe(Context context);
 
+    /** Subscription context. */
     interface Context {
 
+      /**
+       * Stream options, to set the offset to start consuming from.
+       *
+       * <p>Only the {@link StreamOptions} are accessible, the {@link StreamOptions#builder()}
+       * method returns <code>null</code>
+       *
+       * @return the stream options
+       * @see StreamOptions
+       */
       ConsumerBuilder.StreamOptions streamOptions();
     }
   }

--- a/src/main/java/com/rabbitmq/client/amqp/ConsumerBuilder.java
+++ b/src/main/java/com/rabbitmq/client/amqp/ConsumerBuilder.java
@@ -74,6 +74,8 @@ public interface ConsumerBuilder {
    */
   StreamOptions stream();
 
+  ConsumerBuilder subscriptionListener(SubscriptionListener subscriptionListener);
+
   /**
    * Build the consumer.
    *
@@ -163,5 +165,15 @@ public interface ConsumerBuilder {
     LAST,
     /** Very end of the stream (new chunks). */
     NEXT
+  }
+
+  interface SubscriptionListener {
+
+    void preSubscribe(Context context);
+
+    interface Context {
+
+      ConsumerBuilder.StreamOptions streamOptions();
+    }
   }
 }

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConsumerBuilder.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConsumerBuilder.java
@@ -27,6 +27,8 @@ import java.util.*;
 
 class AmqpConsumerBuilder implements ConsumerBuilder {
 
+  static SubscriptionListener NO_OP_SUBSCRIPTION_LISTENER = ctx -> {};
+
   private final AmqpConnection connection;
   private String queue;
   private Consumer.MessageHandler messageHandler;
@@ -35,6 +37,7 @@ class AmqpConsumerBuilder implements ConsumerBuilder {
   private final Map<String, Object> filters = new LinkedHashMap<>();
   private final Map<String, Object> properties = new LinkedHashMap<>();
   private final StreamOptions streamOptions = new DefaultStreamOptions(this, this.filters);
+  private SubscriptionListener subscriptionListener = NO_OP_SUBSCRIPTION_LISTENER;
 
   AmqpConsumerBuilder(AmqpConnection connection) {
     this.connection = connection;
@@ -77,6 +80,16 @@ class AmqpConsumerBuilder implements ConsumerBuilder {
   @Override
   public StreamOptions stream() {
     return this.streamOptions;
+  }
+
+  @Override
+  public ConsumerBuilder subscriptionListener(SubscriptionListener subscriptionListener) {
+    this.subscriptionListener = subscriptionListener;
+    return this;
+  }
+
+  SubscriptionListener subscriptionListener() {
+    return this.subscriptionListener;
   }
 
   AmqpConnection connection() {
@@ -185,5 +198,9 @@ class AmqpConsumerBuilder implements ConsumerBuilder {
     private void offsetSpecification(Object value) {
       this.filters.put("rabbitmq:stream-offset-spec", value);
     }
+  }
+
+  static StreamOptions streamOptions(Map<String, Object> filters) {
+    return new DefaultStreamOptions(null, filters);
   }
 }

--- a/src/test/java/com/rabbitmq/client/amqp/impl/AmqpConsumerTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/AmqpConsumerTest.java
@@ -1,0 +1,169 @@
+// Copyright (c) 2024 Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+package com.rabbitmq.client.amqp.impl;
+
+import static com.rabbitmq.client.amqp.Management.QueueType.STREAM;
+import static com.rabbitmq.client.amqp.Resource.State.OPEN;
+import static com.rabbitmq.client.amqp.Resource.State.RECOVERING;
+import static com.rabbitmq.client.amqp.impl.Assertions.*;
+import static com.rabbitmq.client.amqp.impl.Cli.closeConnection;
+import static com.rabbitmq.client.amqp.impl.TestUtils.name;
+import static com.rabbitmq.client.amqp.impl.TestUtils.sync;
+import static org.assertj.core.api.Assertions.*;
+
+import com.rabbitmq.client.amqp.*;
+import com.rabbitmq.client.amqp.impl.TestUtils.Sync;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(AmqpTestInfrastructureExtension.class)
+public class AmqpConsumerTest {
+
+  BackOffDelayPolicy backOffDelayPolicy = BackOffDelayPolicy.fixed(Duration.ofMillis(100));
+  Environment environment;
+  Connection connection;
+  String q;
+  String connectionName;
+
+  @BeforeEach
+  void init(TestInfo info) {
+    this.q = name(info);
+    connection.management().queue(this.q).type(STREAM).declare();
+    this.connectionName = ((AmqpConnection) connection).name();
+  }
+
+  @AfterEach
+  void tearDown() {
+    connection.management().queueDeletion().delete(this.q);
+  }
+
+  @Test
+  void subscriptionListenerShouldBeCalledOnRecovery() {
+    Sync subscriptionSync = sync();
+    Sync recoveredSync = sync();
+    connection
+        .consumerBuilder()
+        .queue(this.q)
+        .subscriptionListener(ctx -> subscriptionSync.down())
+        .listeners(recoveredListener(recoveredSync))
+        .messageHandler((ctx, msg) -> {})
+        .build();
+
+    assertThat(subscriptionSync).completes();
+    assertThat(recoveredSync).hasNotCompleted();
+    sync().reset();
+    closeConnection(this.connectionName);
+    assertThat(recoveredSync).completes();
+    assertThat(subscriptionSync).completes();
+  }
+
+  @Test
+  void streamConsumerRestartsWhereItLeftOff() {
+    Connection publisherConnection = environment.connectionBuilder().build();
+    Publisher publisher = publisherConnection.publisherBuilder().queue(this.q).build();
+    int messageCount = 100;
+    Runnable publish =
+        () -> {
+          Sync publishSync = sync(messageCount);
+          Publisher.Callback callback = ctx -> publishSync.down();
+          IntStream.range(0, messageCount)
+              .forEach(
+                  ignored -> {
+                    publisher.publish(publisher.message(), callback);
+                  });
+          assertThat(publishSync).completes();
+        };
+
+    publish.run();
+
+    Sync consumeSync = sync(messageCount);
+    AtomicLong lastOffsetProcessed = new AtomicLong(-1);
+    AtomicInteger consumedMessageCount = new AtomicInteger(0);
+    AtomicInteger subscriptionListenerCallCount = new AtomicInteger(0);
+    Sync recoveredSync = sync();
+    ConsumerBuilder.SubscriptionListener subscriptionListener =
+        ctx -> {
+          subscriptionListenerCallCount.incrementAndGet();
+          ctx.streamOptions().offset(lastOffsetProcessed.get() + 1);
+        };
+    Consumer.MessageHandler messageHandler =
+        (ctx, msg) -> {
+          long offset = (long) msg.annotation("x-stream-offset");
+          ctx.accept();
+          lastOffsetProcessed.set(offset);
+          consumedMessageCount.incrementAndGet();
+          consumeSync.down();
+        };
+    Consumer consumer =
+        connection
+            .consumerBuilder()
+            .listeners(recoveredListener(recoveredSync))
+            .queue(this.q)
+            .subscriptionListener(subscriptionListener)
+            .messageHandler(messageHandler)
+            .build();
+
+    assertThat(subscriptionListenerCallCount).hasValue(1);
+    assertThat(consumeSync).completes();
+
+    closeConnection(this.connectionName);
+    assertThat(recoveredSync).completes();
+    assertThat(subscriptionListenerCallCount).hasValue(2);
+    assertThat(consumedMessageCount).hasValue(messageCount);
+
+    long offsetAfterRecovery = lastOffsetProcessed.get();
+    consumeSync.reset(messageCount);
+    publish.run();
+    assertThat(consumeSync).completes();
+    assertThat(consumedMessageCount).hasValue(messageCount * 2);
+    assertThat(lastOffsetProcessed).hasValueGreaterThan(offsetAfterRecovery);
+
+    consumer.close();
+
+    long offsetAfterClosing = lastOffsetProcessed.get();
+    consumeSync.reset(messageCount);
+    publish.run();
+
+    connection
+        .consumerBuilder()
+        .queue(this.q)
+        .subscriptionListener(subscriptionListener)
+        .messageHandler(messageHandler)
+        .build();
+
+    assertThat(subscriptionListenerCallCount).hasValue(3);
+    assertThat(consumeSync).completes();
+    assertThat(consumedMessageCount).hasValue(messageCount * 3);
+    assertThat(lastOffsetProcessed).hasValueGreaterThan(offsetAfterClosing);
+  }
+
+  private static Resource.StateListener recoveredListener(Sync sync) {
+    return context -> {
+      if (context.previousState() == RECOVERING && context.currentState() == OPEN) {
+        sync.down();
+      }
+    };
+  }
+}

--- a/src/test/java/com/rabbitmq/client/amqp/impl/Assertions.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/Assertions.java
@@ -99,6 +99,13 @@ final class Assertions {
       }
       return this;
     }
+
+    SyncAssert hasNotCompleted() {
+      if (actual.hasCompleted()) {
+        fail("Sync '%s' should not have completed", this.actual.toString());
+      }
+      return this;
+    }
   }
 
   static class QueueInfoAssert extends AbstractObjectAssert<QueueInfoAssert, Management.QueueInfo> {

--- a/src/test/java/com/rabbitmq/client/amqp/impl/TestUtils.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/TestUtils.java
@@ -525,6 +525,10 @@ public abstract class TestUtils {
       this.reset(1);
     }
 
+    boolean hasCompleted() {
+      return this.latch.get().getCount() == 0;
+    }
+
     @Override
     public String toString() {
       return this.description;


### PR DESCRIPTION
This consumer hook is called just before creating the receiver link. It allows changing some settings (only the stream-related ones for now). In the case of stream it can be used to look up the last processed offset and attach the stream consumer at this offset.