### PR TITLE
Recover connection if consumer recovery closes it

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '21'
+          java-version: '17'
           cache: 'maven'
 #      - name: Start broker
 #        run: ci/start-broker.sh

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -22,24 +22,22 @@ jobs:
           distribution: 'zulu'
           java-version: '21'
           cache: 'maven'
-      - name: Start broker
-        run: ci/start-broker.sh
-        env:
-          RABBITMQ_IMAGE: 'pivotalrabbitmq/rabbitmq:main'
-      - name: Start toxiproxy
-        run: ci/start-toxiproxy.sh
+#      - name: Start broker
+#        run: ci/start-broker.sh
+#      - name: Start toxiproxy
+#        run: ci/start-toxiproxy.sh
       - name: Display Java version
         run: ./mvnw --version
-      - name: Test
-        run: |
-          ./mvnw verify -Drabbitmqctl.bin=DOCKER:rabbitmq --no-transfer-progress \
-            -Dca.certificate=./tls-gen/basic/result/ca_certificate.pem \
-            -Dclient.certificate=./tls-gen/basic/result/client_$(hostname)_certificate.pem \
-            -Dclient.key=./tls-gen/basic/result/client_$(hostname)_key.pem
-      - name: Stop toxiproxy
-        run: docker stop toxiproxy && docker rm toxiproxy
-      - name: Stop broker
-        run: docker stop rabbitmq && docker rm rabbitmq
+#      - name: Test
+#        run: |
+#          ./mvnw verify -Drabbitmqctl.bin=DOCKER:rabbitmq --no-transfer-progress \
+#            -Dca.certificate=./tls-gen/basic/result/ca_certificate.pem \
+#            -Dclient.certificate=./tls-gen/basic/result/client_$(hostname)_certificate.pem \
+#            -Dclient.key=./tls-gen/basic/result/client_$(hostname)_key.pem
+#      - name: Stop toxiproxy
+#        run: docker stop toxiproxy && docker rm toxiproxy
+#      - name: Stop broker
+#        run: docker stop rabbitmq && docker rm rabbitmq
       - name: Start cluster
         run: ci/start-cluster.sh
       - name: Test against cluster

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -20,24 +20,24 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '21'
           cache: 'maven'
-#      - name: Start broker
-#        run: ci/start-broker.sh
-#      - name: Start toxiproxy
-#        run: ci/start-toxiproxy.sh
+      - name: Start broker
+        run: ci/start-broker.sh
+      - name: Start toxiproxy
+        run: ci/start-toxiproxy.sh
       - name: Display Java version
         run: ./mvnw --version
-#      - name: Test
-#        run: |
-#          ./mvnw verify -Drabbitmqctl.bin=DOCKER:rabbitmq --no-transfer-progress \
-#            -Dca.certificate=./tls-gen/basic/result/ca_certificate.pem \
-#            -Dclient.certificate=./tls-gen/basic/result/client_$(hostname)_certificate.pem \
-#            -Dclient.key=./tls-gen/basic/result/client_$(hostname)_key.pem
-#      - name: Stop toxiproxy
-#        run: docker stop toxiproxy && docker rm toxiproxy
-#      - name: Stop broker
-#        run: docker stop rabbitmq && docker rm rabbitmq
+      - name: Test
+        run: |
+          ./mvnw verify -Drabbitmqctl.bin=DOCKER:rabbitmq --no-transfer-progress \
+            -Dca.certificate=./tls-gen/basic/result/ca_certificate.pem \
+            -Dclient.certificate=./tls-gen/basic/result/client_$(hostname)_certificate.pem \
+            -Dclient.key=./tls-gen/basic/result/client_$(hostname)_key.pem
+      - name: Stop toxiproxy
+        run: docker stop toxiproxy && docker rm toxiproxy
+      - name: Stop broker
+        run: docker stop rabbitmq && docker rm rabbitmq
       - name: Start cluster
         run: ci/start-cluster.sh
       - name: Test against cluster

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConnection.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConnection.java
@@ -479,8 +479,11 @@ final class AmqpConnection extends ResourceBase implements Connection {
         try {
           LOGGER.debug("Recovering consumer {} (queue '{}')", consumer.id(), consumer.queue());
           consumer.recoverAfterConnectionFailure();
+
           consumer.state(OPEN);
           LOGGER.debug("Recovered consumer {} (queue '{}')", consumer.id(), consumer.queue());
+        } catch (AmqpException.AmqpConnectionException ex) {
+          throw ex;
         } catch (Exception ex) {
           LOGGER.warn(
               "Error while trying to recover consumer {} (queue '{}')",

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConnection.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConnection.java
@@ -388,7 +388,7 @@ final class AmqpConnection extends ResourceBase implements Connection {
                 this.state(OPEN);
               } catch (Exception ex) {
                 // likely InterruptedException or IO exception
-                LOGGER.info(
+                LOGGER.warn(
                     "Error while trying to recover topology for connection '{}': {}",
                     this.name(),
                     ex.getMessage());
@@ -479,10 +479,14 @@ final class AmqpConnection extends ResourceBase implements Connection {
         try {
           LOGGER.debug("Recovering consumer {} (queue '{}')", consumer.id(), consumer.queue());
           consumer.recoverAfterConnectionFailure();
-
           consumer.state(OPEN);
           LOGGER.debug("Recovered consumer {} (queue '{}')", consumer.id(), consumer.queue());
         } catch (AmqpException.AmqpConnectionException ex) {
+          LOGGER.warn(
+              "Connection error while trying to recover consumer {} (queue '{}'), restarting recovery",
+              consumer.id(),
+              consumer.queue(),
+              ex);
           throw ex;
         } catch (Exception ex) {
           LOGGER.warn(


### PR DESCRIPTION
A stream may not be ready yet for a consumer ("no proc" error), which makes the broker close the whole connection.

This commit propagates the connection exception which trigger recovery.