### PR TITLE
Remove consumer executor service

### DIFF
--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpEnvironment.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpEnvironment.java
@@ -37,12 +37,10 @@ class AmqpEnvironment implements Environment {
   private final AtomicBoolean closed = new AtomicBoolean(false);
   private final boolean internalExecutor;
   private final boolean internalScheduledExecutor;
-  private final boolean internalConsumerExecutor;
   private final boolean internalPublisherExecutor;
   private final ExecutorService executorService;
   private final ScheduledExecutorService scheduledExecutorService;
   private final ExecutorService publisherExecutorService;
-  private final ExecutorService consumerExecutorService;
   private final ConnectionManager connectionManager = new ConnectionManager(this);
   private final long id;
   private final Clock clock = new Clock();
@@ -58,7 +56,6 @@ class AmqpEnvironment implements Environment {
       ExecutorService executorService,
       ScheduledExecutorService scheduledExecutorService,
       ExecutorService publisherExecutorService,
-      ExecutorService consumerExecutorService,
       DefaultConnectionSettings<?> connectionSettings,
       MetricsCollector metricsCollector,
       ObservationCollector observationCollector) {
@@ -90,14 +87,6 @@ class AmqpEnvironment implements Environment {
     } else {
       this.publisherExecutorService = publisherExecutorService;
       this.internalPublisherExecutor = false;
-    }
-    if (consumerExecutorService == null) {
-      this.consumerExecutorService =
-          Executors.newCachedThreadPool(Utils.threadFactory(threadPrefix + "consumer-"));
-      this.internalConsumerExecutor = true;
-    } else {
-      this.consumerExecutorService = consumerExecutorService;
-      this.internalConsumerExecutor = false;
     }
     this.metricsCollector =
         metricsCollector == null ? NoOpMetricsCollector.INSTANCE : metricsCollector;
@@ -147,9 +136,6 @@ class AmqpEnvironment implements Environment {
       if (this.internalPublisherExecutor) {
         this.publisherExecutorService.shutdownNow();
       }
-      if (this.internalConsumerExecutor) {
-        this.consumerExecutorService.shutdownNow();
-      }
       if (this.clockRefreshFuture != null) {
         this.clockRefreshFuture.cancel(false);
       }
@@ -168,10 +154,6 @@ class AmqpEnvironment implements Environment {
 
   ExecutorService publisherExecutorService() {
     return this.publisherExecutorService;
-  }
-
-  ExecutorService consumerExecutorService() {
-    return this.consumerExecutorService;
   }
 
   ScheduledExecutorService scheduledExecutorService() {

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpEnvironmentBuilder.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpEnvironmentBuilder.java
@@ -35,7 +35,6 @@ public class AmqpEnvironmentBuilder implements EnvironmentBuilder {
   private ExecutorService executorService;
   private ScheduledExecutorService scheduledExecutorService;
   private ExecutorService publisherExecutorService;
-  private ExecutorService consumerExecutorService;
   private MetricsCollector metricsCollector = NoOpMetricsCollector.INSTANCE;
   private ObservationCollector observationCollector = Utils.NO_OP_OBSERVATION_COLLECTOR;
 
@@ -82,15 +81,18 @@ public class AmqpEnvironmentBuilder implements EnvironmentBuilder {
   }
 
   /**
-   * Set executor service used for consumer loops.
+   * Deprecated, do not use anymore. Consumers do not use a polling loop anymore.
+   *
+   * <p>Set executor service used for consumer loops.
    *
    * <p>The library uses sensible defaults, override only in case of problems.
    *
    * @param consumerExecutorService the executor service
    * @return this builder instance
+   * @deprecated Do not use anymore
    */
+  @Deprecated(forRemoval = true)
   public AmqpEnvironmentBuilder consumerExecutorService(ExecutorService consumerExecutorService) {
-    this.consumerExecutorService = consumerExecutorService;
     return this;
   }
 
@@ -144,7 +146,6 @@ public class AmqpEnvironmentBuilder implements EnvironmentBuilder {
         executorService,
         scheduledExecutorService,
         publisherExecutorService,
-        consumerExecutorService,
         connectionSettings,
         metricsCollector,
         observationCollector);

--- a/src/test/java/com/rabbitmq/client/amqp/impl/AmqpConnectionRecoveryTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/AmqpConnectionRecoveryTest.java
@@ -59,7 +59,6 @@ public class AmqpConnectionRecoveryTest {
             null,
             null,
             null,
-            null,
             connectionSettings,
             NoOpMetricsCollector.INSTANCE,
             Utils.NO_OP_OBSERVATION_COLLECTOR);


### PR DESCRIPTION
It was used for consumer polling loops, but consumers do not work this way anymore.

The method to set it in the environment builder has been deprecated and is now a no-op.

References #93