### PR TITLE
Deprecate exchangeDeletion and queueDeletion methods

### DIFF
--- a/src/main/java/com/rabbitmq/client/amqp/Management.java
+++ b/src/main/java/com/rabbitmq/client/amqp/Management.java
@@ -55,8 +55,24 @@ public interface Management extends AutoCloseable {
    * Delete a queue.
    *
    * @return the queue deletion
+   * @deprecated use {@link #queueDelete(String)} instead
    */
+  @Deprecated(forRemoval = true)
   QueueDeletion queueDeletion();
+
+  /**
+   * Delete a queue.
+   *
+   * @param name the name of the queue
+   */
+  void queueDelete(String name);
+
+  /**
+   * Purge (delete all messages) from a queue.
+   *
+   * @param queue queue to delete messages from
+   */
+  void queuePurge(String queue);
 
   /**
    * Start exchange specification.
@@ -77,8 +93,17 @@ public interface Management extends AutoCloseable {
    * Delete an exchange.
    *
    * @return the exchange deletion
+   * @deprecated use {@link #exchangeDelete(String)} instead
    */
+  @Deprecated(forRemoval = true)
   ExchangeDeletion exchangeDeletion();
+
+  /**
+   * Delete an exchange.
+   *
+   * @param name the name of the exchange
+   */
+  void exchangeDelete(String name);
 
   /**
    * Start binding specification.
@@ -93,8 +118,6 @@ public interface Management extends AutoCloseable {
    * @return the unbinding specification
    */
   UnbindSpecification unbind();
-
-  void queuePurge(String queue);
 
   /** Close the management instance and release its resources. */
   @Override
@@ -575,7 +598,12 @@ public interface Management extends AutoCloseable {
     }
   }
 
-  /** Queue deletion. */
+  /**
+   * Queue deletion.
+   *
+   * @deprecated use {@link #queueDelete(String)} instead
+   */
+  @Deprecated(forRemoval = true)
   interface QueueDeletion {
 
     /**
@@ -674,7 +702,12 @@ public interface Management extends AutoCloseable {
     HEADERS
   }
 
-  /** Exchange deletion. */
+  /**
+   * Exchange deletion.
+   *
+   * @deprecated use {@link #exchangeDelete(String)} instead
+   */
+  @Deprecated(forRemoval = true)
   interface ExchangeDeletion {
 
     /**

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpManagement.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpManagement.java
@@ -130,15 +130,19 @@ class AmqpManagement implements Management {
   }
 
   @Override
+  @SuppressWarnings("removal")
   public QueueDeletion queueDeletion() {
+    return this::queueDelete;
+  }
+
+  @Override
+  public void queueDelete(String name) {
     checkAvailable();
-    return name -> {
-      Map<String, Object> responseBody = delete(queueLocation(name), CODE_200);
-      this.topologyListener.queueDeleted(name);
-      if (!responseBody.containsKey("message_count")) {
-        throw new AmqpException("Response body should contain message_count");
-      }
-    };
+    Map<String, Object> responseBody = delete(queueLocation(name), CODE_200);
+    this.topologyListener.queueDeleted(name);
+    if (!responseBody.containsKey("message_count")) {
+      throw new AmqpException("Response body should contain message_count");
+    }
   }
 
   @Override
@@ -154,12 +158,16 @@ class AmqpManagement implements Management {
   }
 
   @Override
+  @SuppressWarnings("removal")
   public ExchangeDeletion exchangeDeletion() {
+    return this::exchangeDelete;
+  }
+
+  @Override
+  public void exchangeDelete(String name) {
     checkAvailable();
-    return name -> {
-      this.delete(exchangeLocation(name), CODE_204);
-      this.topologyListener.exchangeDeleted(name);
-    };
+    this.delete(exchangeLocation(name), CODE_204);
+    this.topologyListener.exchangeDeleted(name);
   }
 
   @Override

--- a/src/test/java/com/rabbitmq/client/amqp/docs/WebsiteDocumentation.java
+++ b/src/test/java/com/rabbitmq/client/amqp/docs/WebsiteDocumentation.java
@@ -188,7 +188,7 @@ public class WebsiteDocumentation {
         .argument("x-delayed-type", "direct")
         .declare();
 
-    management.exchangeDeletion().delete("my-exchange");
+    management.exchangeDelete("my-exchange");
   }
 
   void managementQueues() {
@@ -222,7 +222,7 @@ public class WebsiteDocumentation {
     int consumerCount = info.consumerCount();
     String leaderNode = info.leader();
 
-    management.queueDeletion().delete("my-queue");
+    management.queueDelete("my-queue");
   }
 
   void binding() {

--- a/src/test/java/com/rabbitmq/client/amqp/impl/AddressFormatTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/AddressFormatTest.java
@@ -67,8 +67,8 @@ public class AddressFormatTest {
       publisher.publish(publisher.message(), ctx -> {});
       Assertions.assertThat(consumeLatch).completes();
     } finally {
-      management.queueDeletion().delete(q);
-      management.exchangeDeletion().delete(e);
+      management.queueDelete(q);
+      management.exchangeDelete(e);
     }
   }
 
@@ -108,8 +108,8 @@ public class AddressFormatTest {
       publisher.publish(publisher.message(), ctx -> {});
       Assertions.assertThat(consumeLatch).completes();
     } finally {
-      management.queueDeletion().delete(q);
-      management.exchangeDeletion().delete(e);
+      management.queueDelete(q);
+      management.exchangeDelete(e);
     }
   }
 
@@ -136,7 +136,7 @@ public class AddressFormatTest {
       publisher.publish(publisher.message(), ctx -> {});
       Assertions.assertThat(consumeLatch).completes();
     } finally {
-      management.queueDeletion().delete(q);
+      management.queueDelete(q);
     }
   }
 
@@ -185,8 +185,8 @@ public class AddressFormatTest {
       publisher.publish(publisher.message().toAddress().queue(q).message(), ctx -> {});
       Assertions.assertThat(consumeLatch).completes();
     } finally {
-      management.queueDeletion().delete(q);
-      management.exchangeDeletion().delete(e);
+      management.queueDelete(q);
+      management.exchangeDelete(e);
     }
   }
 

--- a/src/test/java/com/rabbitmq/client/amqp/impl/AffinityTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/AffinityTest.java
@@ -59,7 +59,7 @@ public class AffinityTest {
       assertThat(c1.id()).isNotEqualTo(c2.id());
       assertThat(c3.id()).isIn(c1.id(), c2.id());
     } finally {
-      management.queueDeletion().delete(name);
+      management.queueDelete(name);
     }
   }
 

--- a/src/test/java/com/rabbitmq/client/amqp/impl/AmqpConnectionRecoveryTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/AmqpConnectionRecoveryTest.java
@@ -167,7 +167,7 @@ public class AmqpConnectionRecoveryTest {
           .hasSameSizeAs(publishedMessageIds)
           .containsAll(publishedMessageIds);
     } finally {
-      c.management().queueDeletion().delete(q);
+      c.management().queueDelete(q);
       c.close();
     }
   }

--- a/src/test/java/com/rabbitmq/client/amqp/impl/AmqpConsumerTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/AmqpConsumerTest.java
@@ -55,7 +55,7 @@ public class AmqpConsumerTest {
   @AfterEach
   void tearDown() {
     waitAtMost(Duration.ofSeconds(5), () -> ((ResourceBase) connection).state() == OPEN);
-    connection.management().queueDeletion().delete(this.q);
+    connection.management().queueDelete(this.q);
   }
 
   @Test

--- a/src/test/java/com/rabbitmq/client/amqp/impl/AmqpTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/AmqpTest.java
@@ -76,7 +76,7 @@ public class AmqpTest {
           .hasArgument("x-queue-type", "quorum");
 
     } finally {
-      management.queueDeletion().delete(name);
+      management.queueDelete(name);
     }
   }
 
@@ -131,7 +131,7 @@ public class AmqpTest {
       consumer.close();
       publisher.close();
     } finally {
-      connection.management().queueDeletion().delete(name);
+      connection.management().queueDelete(name);
     }
   }
 
@@ -215,9 +215,9 @@ public class AmqpTest {
           .key(rk)
           .arguments(bindingArguments)
           .unbind();
-      management.exchangeDeletion().delete(e2);
-      management.exchangeDeletion().delete(e1);
-      management.queueDeletion().delete(q);
+      management.exchangeDelete(e2);
+      management.exchangeDelete(e1);
+      management.queueDelete(q);
     }
   }
 
@@ -313,7 +313,7 @@ public class AmqpTest {
       publisher.publish(publisher.message(), acceptedCallback(sync));
       assertThat(sync).completes();
     } finally {
-      connection.management().exchangeDeletion().delete(name);
+      connection.management().exchangeDelete(name);
     }
     AtomicReference<Exception> exception = new AtomicReference<>();
     waitAtMost(
@@ -361,7 +361,7 @@ public class AmqpTest {
       publisher.publish(publisher.message(), acceptedCallback(sync));
       assertThat(sync).completes();
     } finally {
-      connection.management().queueDeletion().delete(name);
+      connection.management().queueDelete(name);
     }
     AtomicReference<Exception> exception = new AtomicReference<>();
     waitAtMost(
@@ -461,7 +461,7 @@ public class AmqpTest {
     Publisher publisher = connection.publisherBuilder().queue(name).build();
     publisher.publish(publisher.message(), ctx -> {});
     assertThat(consumeSync).completes();
-    connection.management().queueDeletion().delete(name);
+    connection.management().queueDelete(name);
     assertThat(closedSync).completes();
     org.assertj.core.api.Assertions.assertThat(exception.get())
         .isInstanceOf(AmqpException.AmqpEntityDoesNotExistException.class)
@@ -642,7 +642,7 @@ public class AmqpTest {
     } catch (AmqpException e) {
       // OK
     } finally {
-      management.queueDeletion().delete(name);
+      management.queueDelete(name);
     }
   }
 
@@ -657,7 +657,7 @@ public class AmqpTest {
       org.assertj.core.api.Assertions.assertThat(e).hasMessageContaining("409");
       // OK
     } finally {
-      management.exchangeDeletion().delete(name);
+      management.exchangeDelete(name);
     }
   }
 
@@ -703,7 +703,7 @@ public class AmqpTest {
           .forEach(ignored -> publisher.publish(publisher.message(), callback));
       assertThat(rejectedLatch).completes();
     } finally {
-      management.queueDeletion().delete(q);
+      management.queueDelete(q);
     }
   }
 

--- a/src/test/java/com/rabbitmq/client/amqp/impl/AuthorizationTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/AuthorizationTest.java
@@ -87,7 +87,7 @@ public class AuthorizationTest {
       waitAtMost(
           () -> {
             try {
-              c.management().queueDeletion().delete(authorizedName);
+              c.management().queueDelete(authorizedName);
               return true;
             } catch (AmqpException e) {
               return false;
@@ -121,7 +121,7 @@ public class AuthorizationTest {
             .hasMessageContaining("access")
             .hasMessageContaining(this.name);
       } finally {
-        gc.management().exchangeDeletion().delete(this.name);
+        gc.management().exchangeDelete(this.name);
       }
     }
   }
@@ -136,7 +136,7 @@ public class AuthorizationTest {
             .isInstanceOf(AmqpException.AmqpSecurityException.class)
             .hasMessageContaining("access");
       } finally {
-        gc.management().queueDeletion().delete(this.name);
+        gc.management().queueDelete(this.name);
       }
     }
   }
@@ -165,7 +165,7 @@ public class AuthorizationTest {
             .hasMessageContaining("access")
             .hasMessageContaining(this.name);
       } finally {
-        gc.management().exchangeDeletion().delete(this.name);
+        gc.management().exchangeDelete(this.name);
       }
     }
   }
@@ -183,7 +183,7 @@ public class AuthorizationTest {
             .hasMessageContaining("access")
             .hasMessageContaining(this.name);
       } finally {
-        gc.management().queueDeletion().delete(this.name);
+        gc.management().queueDelete(this.name);
       }
     }
   }

--- a/src/test/java/com/rabbitmq/client/amqp/impl/ClientTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/ClientTest.java
@@ -68,7 +68,7 @@ public class ClientTest {
 
   @AfterEach
   void tearDown() {
-    management.queueDeletion().delete(q);
+    management.queueDelete(q);
   }
 
   @AfterAll
@@ -272,7 +272,7 @@ public class ClientTest {
       receiver.openFuture().get();
       Delivery delivery = receiver.tryReceive();
       assertThat(delivery).isNull();
-      connection.management().queueDeletion().delete(queue);
+      connection.management().queueDelete(queue);
       try {
         receiver.receive(10, SECONDS);
         fail("Receiver should have been closed after queue deletion");
@@ -306,7 +306,7 @@ public class ClientTest {
       tracker.awaitSettlement(10, SECONDS);
       assertThat(tracker.remoteState()).isEqualTo(DeliveryState.accepted());
 
-      connection.management().exchangeDeletion().delete(exchange);
+      connection.management().exchangeDelete(exchange);
       try {
         int count = 0;
         while (count++ < 10) {

--- a/src/test/java/com/rabbitmq/client/amqp/impl/ClusterTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/ClusterTest.java
@@ -89,7 +89,7 @@ public class ClusterTest {
           .isNotEqualTo(info.leader());
       assertThat(Cli.listConnections()).hasSize(3);
     } finally {
-      management.queueDeletion().delete(q);
+      management.queueDelete(q);
     }
   }
 
@@ -117,7 +117,7 @@ public class ClusterTest {
       assertThat(recoveredSync).completes();
       assertThat(publishConnection.connectionNodename()).isEqualTo(newLeader);
     } finally {
-      management.queueDeletion().delete(q);
+      management.queueDelete(q);
     }
   }
 
@@ -161,7 +161,7 @@ public class ClusterTest {
       assertThat(consumeSync).completes();
       assertThat(messageIds).containsExactlyInAnyOrder(1L, 2L, 3L);
     } finally {
-      management.queueDeletion().delete(q);
+      management.queueDelete(q);
     }
   }
 
@@ -218,7 +218,7 @@ public class ClusterTest {
       assertThat(messageIds).containsExactlyInAnyOrder(1L, 2L, 3L);
       consumeSync.reset();
     } finally {
-      management.queueDeletion().delete(q);
+      management.queueDelete(q);
     }
   }
 
@@ -277,7 +277,7 @@ public class ClusterTest {
       assertThat(messageIds).containsExactlyInAnyOrder(1L, 2L, 3L);
       consumeSync.reset();
     } finally {
-      management.queueDeletion().delete(q);
+      management.queueDelete(q);
     }
   }
 
@@ -351,7 +351,7 @@ public class ClusterTest {
       if (nodePaused) {
         Cli.unpauseNode(initialLeader);
       }
-      management.queueDeletion().delete(q);
+      management.queueDelete(q);
     }
   }
 
@@ -391,7 +391,7 @@ public class ClusterTest {
       assertThat(consumeSync).completes();
       assertThat(messageIds).containsExactlyInAnyOrder(1L, 2L);
     } finally {
-      management.queueDeletion().delete(q);
+      management.queueDelete(q);
     }
   }
 
@@ -435,7 +435,7 @@ public class ClusterTest {
       assertThat(consumeSync).completes();
       assertThat(messageIds).containsExactlyInAnyOrder(1L, 2L);
     } finally {
-      management.queueDeletion().delete(q);
+      management.queueDelete(q);
     }
   }
 
@@ -479,7 +479,7 @@ public class ClusterTest {
                       .hasNodename(queueInfos.get(i).leader()));
 
     } finally {
-      names.forEach(n -> management.queueDeletion().delete(n));
+      names.forEach(n -> management.queueDelete(n));
     }
   }
 
@@ -529,7 +529,7 @@ public class ClusterTest {
                   "detected as a no-running-stream-member-on-connection-node exception"));
 
     } finally {
-      this.connection.management().queueDeletion().delete(this.name);
+      this.connection.management().queueDelete(this.name);
       connections.forEach(Connection::close);
     }
   }

--- a/src/test/java/com/rabbitmq/client/amqp/impl/ConsumerOutcomeTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/ConsumerOutcomeTest.java
@@ -76,7 +76,7 @@ public class ConsumerOutcomeTest {
 
   @AfterEach
   void tearDown() {
-    this.connection.management().queueDeletion().delete(q);
+    this.connection.management().queueDelete(q);
   }
 
   @Test

--- a/src/test/java/com/rabbitmq/client/amqp/impl/ManagementTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/ManagementTest.java
@@ -149,7 +149,7 @@ public class ManagementTest {
       if (c != null) {
         c.close();
       }
-      this.connection.management().queueDeletion().delete(q);
+      this.connection.management().queueDelete(q);
       deleteUser(username);
     }
   }

--- a/src/test/java/com/rabbitmq/client/amqp/impl/RecoveryClusterTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/RecoveryClusterTest.java
@@ -302,7 +302,7 @@ public class RecoveryClusterTest {
       consumerStates.forEach(ConsumerState::close);
       queueConfigurations.stream()
           .filter(c -> !c.exclusive)
-          .forEach(c -> management.queueDeletion().delete(c.name));
+          .forEach(c -> management.queueDelete(c.name));
     }
   }
 

--- a/src/test/java/com/rabbitmq/client/amqp/impl/ResourceListenerTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/ResourceListenerTest.java
@@ -48,11 +48,11 @@ public class ResourceListenerTest {
     Consumer<PublisherBuilder> builderConfigurator;
     if (toExchange) {
       declare = () -> connection.management().exchange(entity).declare();
-      delete = () -> connection.management().exchangeDeletion().delete(entity);
+      delete = () -> connection.management().exchangeDelete(entity);
       builderConfigurator = b -> b.exchange(entity);
     } else {
       declare = () -> connection.management().queue(entity).declare();
-      delete = () -> connection.management().queueDeletion().delete(entity);
+      delete = () -> connection.management().queueDelete(entity);
       builderConfigurator = b -> b.queue(entity);
     }
     CountDownLatch closedLatch = new CountDownLatch(1);
@@ -128,7 +128,7 @@ public class ResourceListenerTest {
       com.rabbitmq.client.amqp.impl.Assertions.assertThat(consumeLatch).completes();
 
     } finally {
-      connection.management().queueDeletion().delete(q);
+      connection.management().queueDelete(q);
     }
     com.rabbitmq.client.amqp.impl.Assertions.assertThat(closedLatch).completes();
     Assertions.assertThat(closeCause.get()).isNotNull().isInstanceOf(AmqpException.class);

--- a/src/test/java/com/rabbitmq/client/amqp/impl/RpcTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/RpcTest.java
@@ -268,7 +268,7 @@ public class RpcTest {
       response = rpcClient.publish(rpcClient.message(requestBody).messageId(UUID.randomUUID()));
       assertThat(response.get(10, TimeUnit.SECONDS).body()).isEqualTo(process(requestBody));
     } finally {
-      serverConnection.management().queueDeletion().delete(requestQueue);
+      serverConnection.management().queueDelete(requestQueue);
       serverConnection.close();
     }
   }

--- a/src/test/java/com/rabbitmq/client/amqp/impl/SourceFiltersTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/SourceFiltersTest.java
@@ -63,7 +63,7 @@ public class SourceFiltersTest {
 
   @AfterEach
   void tearDown() {
-    connection.management().queueDeletion().delete(this.name);
+    connection.management().queueDelete(this.name);
   }
 
   @Test

--- a/src/test/java/com/rabbitmq/client/amqp/impl/TopologyRecoveryTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/TopologyRecoveryTest.java
@@ -146,11 +146,11 @@ public class TopologyRecoveryTest {
       assertThat(events).contains("bindingDeleted");
       assertThat(eventCount).hasValue(6);
 
-      management.exchangeDeletion().delete(e);
+      management.exchangeDelete(e);
       assertThat(events).contains("exchangeDeleted");
       assertThat(eventCount).hasValue(7);
 
-      management.queueDeletion().delete(q);
+      management.queueDelete(q);
       assertThat(events).contains("queueDeleted");
       assertThat(eventCount).hasValue(8);
     }
@@ -352,8 +352,8 @@ public class TopologyRecoveryTest {
       assertThat(acceptedLatch).completes();
       assertThat(connection.management().queueInfo(q)).isEmpty();
     } finally {
-      connection.management().queueDeletion().delete(q);
-      connection.management().exchangeDeletion().delete(e);
+      connection.management().queueDelete(q);
+      connection.management().exchangeDelete(e);
       connection.close();
     }
   }
@@ -408,9 +408,9 @@ public class TopologyRecoveryTest {
       assertThat(acceptedLatch).completes();
       assertThat(connection.management().queueInfo(q)).isEmpty();
     } finally {
-      connection.management().queueDeletion().delete(q);
-      connection.management().exchangeDeletion().delete(e2);
-      connection.management().exchangeDeletion().delete(e1);
+      connection.management().queueDelete(q);
+      connection.management().exchangeDelete(e2);
+      connection.management().exchangeDelete(e1);
       connection.close();
     }
   }
@@ -422,7 +422,7 @@ public class TopologyRecoveryTest {
       assertThat(connectionAttemptCount).hasValue(1);
       connection.management().exchange(e).declare();
       Assertions.assertThat(Cli.exchangeExists(e)).isTrue();
-      connection.management().exchangeDeletion().delete(e);
+      connection.management().exchangeDelete(e);
       closeConnectionAndWaitForRecovery();
       assertThat(connectionAttemptCount).hasValue(2);
       Assertions.assertThat(Cli.exchangeExists(e)).isFalse();
@@ -436,7 +436,7 @@ public class TopologyRecoveryTest {
       assertThat(connectionAttemptCount).hasValue(1);
       connection.management().queue(q).declare();
       assertThat(connection.management().queueInfo(q)).hasName(q);
-      connection.management().queueDeletion().delete(q);
+      connection.management().queueDelete(q);
       closeConnectionAndWaitForRecovery();
       assertThat(connectionAttemptCount).hasValue(2);
       assertThatThrownBy(() -> connection.management().queueInfo(q))
@@ -460,7 +460,7 @@ public class TopologyRecoveryTest {
       assertThat(connectionAttemptCount).hasValue(2);
       TestUtils.waitAtMost(() -> connection.management().queueInfo(q).consumerCount() == 0);
     } finally {
-      connection.management().queueDeletion().delete(q);
+      connection.management().queueDelete(q);
       connection.close();
     }
   }
@@ -498,8 +498,8 @@ public class TopologyRecoveryTest {
       assertThat(consumeSync).completes();
       assertThat(connection.management().queueInfo(q)).isEmpty().hasConsumerCount(consumerCount);
     } finally {
-      connection.management().queueDeletion().delete(q);
-      connection.management().exchangeDeletion().delete(e);
+      connection.management().queueDelete(q);
+      connection.management().exchangeDelete(e);
       connection.close();
     }
   }
@@ -540,8 +540,8 @@ public class TopologyRecoveryTest {
               });
 
     } finally {
-      connection.management().queueDeletion().delete(q);
-      connection.management().exchangeDeletion().delete(e);
+      connection.management().queueDelete(q);
+      connection.management().exchangeDelete(e);
       connection.close();
     }
   }
@@ -593,7 +593,7 @@ public class TopologyRecoveryTest {
 
       TestUtils.waitAtMost(() -> connection.management().queueInfo(q).messageCount() == 0);
     } finally {
-      connection.management().queueDeletion().delete(q);
+      connection.management().queueDelete(q);
     }
   }
 

--- a/src/test/java/com/rabbitmq/client/amqp/perf/AmqpPerfTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/perf/AmqpPerfTest.java
@@ -76,8 +76,8 @@ public class AmqpPerfTest {
             metrics.close();
             executorService.shutdownNow();
             shutdownLatch.countDown();
-            management.queueDeletion().delete(q);
-            management.exchangeDeletion().delete(e);
+            management.queueDelete(q);
+            management.exchangeDelete(e);
             management.close();
           }
         };


### PR DESCRIPTION
In favor of exchangeDelete and queueDelete, simpler.