### PR TITLE
Make message durability configurable

### DIFF
--- a/src/main/java/com/rabbitmq/client/amqp/Message.java
+++ b/src/main/java/com/rabbitmq/client/amqp/Message.java
@@ -592,6 +592,19 @@ public interface Message {
   byte[] body();
 
   /**
+   * Mark the message as durable or not.
+   *
+   * <p>Messages are durable by default, use <code>false</code> to make them explicitly non-durable.
+   *
+   * <p>Durability depends also on the queue messages end up in (e.g. quorum queues and streams
+   * always store messages durably).
+   *
+   * @param durable true for a durable message, false for a non-durable message
+   * @return the message
+   */
+  Message durable(boolean durable);
+
+  /**
    * Whether the message is durable.
    *
    * @return true if durable, false otherwise

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpMessage.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpMessage.java
@@ -35,6 +35,8 @@ final class AmqpMessage implements Message {
 
   private final org.apache.qpid.protonj2.client.Message<byte[]> delegate;
 
+  private boolean durableIsSet = false;
+
   AmqpMessage() {
     this(org.apache.qpid.protonj2.client.Message.create(EMPTY_BODY));
   }
@@ -455,6 +457,14 @@ final class AmqpMessage implements Message {
   }
 
   // header section
+
+  @Override
+  public Message durable(boolean durable) {
+    this.durableIsSet = true;
+    callOnDelegate(m -> m.durable(durable));
+    return this;
+  }
+
   @Override
   public boolean durable() {
     return returnFromDelegate(org.apache.qpid.protonj2.client.Message::durable);
@@ -533,6 +543,13 @@ final class AmqpMessage implements Message {
   @Override
   public MessageAddressBuilder replyToAddress() {
     return new DefaultMessageAddressBuilder(this, DefaultMessageAddressBuilder.REPLY_TO_CALLBACK);
+  }
+
+  AmqpMessage enforceDurability() throws ClientException {
+    if (!this.durableIsSet) {
+      this.delegate.durable(true);
+    }
+    return this;
   }
 
   private static class DefaultMessageAddressBuilder

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpPublisher.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpPublisher.java
@@ -86,9 +86,7 @@ final class AmqpPublisher extends ResourceBase implements Publisher {
     this.publishCall =
         msg -> {
           try {
-            org.apache.qpid.protonj2.client.Message<?> nativeMessage =
-                ((AmqpMessage) msg).nativeMessage();
-            return this.sender.send(nativeMessage.durable(true));
+            return this.doSend((AmqpMessage) msg);
           } catch (ClientIllegalStateException e) {
             // the link is closed
             LOGGER.debug("Error while publishing: '{}'. Closing publisher.", e.getMessage());
@@ -152,6 +150,11 @@ final class AmqpPublisher extends ResourceBase implements Publisher {
       LOGGER.warn("Delivery state not supported: " + in.getType());
       throw new IllegalStateException("This delivery state is not supported: " + in.getType());
     }
+  }
+
+  private Tracker doSend(AmqpMessage msg) throws ClientException {
+    msg.enforceDurability();
+    return this.sender.send(msg.nativeMessage());
   }
 
   private static MetricsCollector.PublishDisposition mapToPublishDisposition(Status status) {

--- a/src/test/java/com/rabbitmq/client/amqp/impl/AmqpMessageTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/AmqpMessageTest.java
@@ -25,13 +25,32 @@ public class AmqpMessageTest {
 
   @Test
   void toShouldBePathEncoded() {
-    assertThat(new AmqpMessage().toAddress().exchange("foo bar").message().to())
+    assertThat(msg().toAddress().exchange("foo bar").message().to())
         .isEqualTo("/exchanges/foo%20bar");
   }
 
   @Test
   void replyToShouldBePathEncoded() {
-    assertThat(new AmqpMessage().replyToAddress().exchange("foo bar").message().replyTo())
+    assertThat(msg().replyToAddress().exchange("foo bar").message().replyTo())
         .isEqualTo("/exchanges/foo%20bar");
+  }
+
+  @Test
+  void shouldBeNonDurableOnlyIfExplicitlySet() throws Exception {
+    AmqpMessage msg = msg();
+    // durable by default
+    assertThat(msg.enforceDurability().nativeMessage().durable()).isTrue();
+    // non-durable explicitly set
+    msg = msg();
+    msg.durable(false);
+    assertThat(msg.enforceDurability().nativeMessage().durable()).isFalse();
+    // durable explicitly set
+    msg = msg();
+    msg.durable(true);
+    assertThat(msg.enforceDurability().nativeMessage().durable()).isTrue();
+  }
+
+  private static AmqpMessage msg() {
+    return new AmqpMessage();
   }
 }

--- a/src/test/java/com/rabbitmq/client/amqp/impl/AmqpTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/AmqpTest.java
@@ -23,6 +23,7 @@ import static com.rabbitmq.client.amqp.Management.QueueType.*;
 import static com.rabbitmq.client.amqp.Management.QueueType.STREAM;
 import static com.rabbitmq.client.amqp.impl.Assertions.assertThat;
 import static com.rabbitmq.client.amqp.impl.TestConditions.BrokerVersion.RABBITMQ_4_0_3;
+import static com.rabbitmq.client.amqp.impl.TestConditions.BrokerVersion.RABBITMQ_4_2_0;
 import static com.rabbitmq.client.amqp.impl.TestUtils.*;
 import static com.rabbitmq.client.amqp.impl.Utils.threadFactory;
 import static java.nio.charset.StandardCharsets.*;
@@ -918,6 +919,7 @@ public class AmqpTest {
     "STREAM,true",
     "STREAM,false"
   })
+  @BrokerVersionAtLeast(RABBITMQ_4_2_0)
   void explicitDurabilityShouldBeEnforced(Management.QueueType type, boolean durable) {
     try {
       connection.management().queue(this.name).type(type).declare();

--- a/src/test/java/com/rabbitmq/client/amqp/impl/Assertions.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/Assertions.java
@@ -359,6 +359,13 @@ public final class Assertions {
           .isEqualTo(expected);
       return this;
     }
+
+    void isDurable(boolean durable) {
+      isNotNull();
+      if (actual.durable() != durable) {
+        fail("Message durable flag should be %s but is %s", durable, actual.durable());
+      }
+    }
   }
 
   static class ConnectionAssert extends AbstractObjectAssert<ConnectionAssert, AmqpConnection> {

--- a/src/test/java/com/rabbitmq/client/amqp/impl/TestConditions.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/TestConditions.java
@@ -35,7 +35,8 @@ public final class TestConditions {
 
   public enum BrokerVersion {
     RABBITMQ_4_0_3("4.0.3"),
-    RABBITMQ_4_1_0("4.1.0");
+    RABBITMQ_4_1_0("4.1.0"),
+    RABBITMQ_4_2_0("4.2.0");
 
     final String value;
 


### PR DESCRIPTION
Outbound messages are marked as durable by default. They are marked non-durable only if explicitly set.