### PR TITLE
Add pre-settled option to consumer builder

### DIFF
--- a/src/main/java/com/rabbitmq/client/amqp/ConsumerBuilder.java
+++ b/src/main/java/com/rabbitmq/client/amqp/ConsumerBuilder.java
@@ -51,6 +51,37 @@ public interface ConsumerBuilder {
   ConsumerBuilder initialCredits(int initialCredits);
 
   /**
+   * Configures the link to use <b>At-Most-Once</b> delivery by receiving messages in a
+   * "pre-settled" state.
+   *
+   * <p>By default, this library uses <b>At-Least-Once</b> delivery, meaning you must explicitly
+   * acknowledge (settle) each message. Calling this method changes that behavior.
+   *
+   * <h3>How it works:</h3>
+   *
+   * <p>When enabled, the server considers the message successfully delivered the moment it is sent.
+   * The message arrives at your application already "settled." Consequently, this library will
+   * <b>not</b> send any acknowledgment (disposition frame) back to the server, and you do not need
+   * to call any settle methods on the received message.
+   *
+   * <h3>Performance vs. Reliability:</h3>
+   *
+   * <ul>
+   *   <li><b>Performance:</b> This is the fastest consumption mode. It eliminates the network
+   *       round-trip overhead of sending acknowledgments.
+   *   <li><b>Reliability:</b> If your application crashes or the connection fails while you are
+   *       processing the message, the message is lost. The server has already discarded it and will
+   *       not redeliver it.
+   * </ul>
+   *
+   * <p>Use this for high-throughput data where the loss of an occasional message is acceptable
+   * (e.g., log streaming, sensor telemetry).
+   *
+   * @return this builder instance
+   */
+  ConsumerBuilder preSettled();
+
+  /**
    * The consumer priority.
    *
    * @param priority consumer priority

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConsumerBuilder.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConsumerBuilder.java
@@ -53,6 +53,7 @@ class AmqpConsumerBuilder implements ConsumerBuilder {
   private boolean directReplyTo = false;
   private Consumer.MessageHandler messageHandler;
   private int initialCredits = 100;
+  private boolean preSettled = false;
   private final List<Resource.StateListener> listeners = new ArrayList<>();
   private final Map<String, DescribedType> filters = new LinkedHashMap<>();
   private final Map<String, Object> properties = new LinkedHashMap<>();
@@ -91,6 +92,12 @@ class AmqpConsumerBuilder implements ConsumerBuilder {
   @Override
   public ConsumerBuilder initialCredits(int initialCredits) {
     this.initialCredits = initialCredits;
+    return this;
+  }
+
+  @Override
+  public ConsumerBuilder preSettled() {
+    this.preSettled = true;
     return this;
   }
 
@@ -143,6 +150,10 @@ class AmqpConsumerBuilder implements ConsumerBuilder {
 
   int initialCredits() {
     return this.initialCredits;
+  }
+
+  boolean isPreSettled() {
+    return this.preSettled;
   }
 
   Map<String, Object> properties() {


### PR DESCRIPTION
Messages arrive already settled from the broker, which makes settlement from the client with a disposition frame not necessary. This is the "fire-and-forget" or "at-most-once" mode. It should be faster but may result in message loss. It is fine for use cases like log streaming or sensor telemetry.

References #316