### PR TITLE
Set large incoming window with 0 incoming capacity

### DIFF
--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConnection.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConnection.java
@@ -733,7 +733,7 @@ final class AmqpConnection extends ResourceBase implements Connection {
 
   private Session openSession(org.apache.qpid.protonj2.client.Connection connection) {
     try {
-      return connection.openSession();
+      return connection.openSession(Utils.sessionOptions());
     } catch (ClientException e) {
       throw convert(e, "Error while opening session");
     }

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpManagement.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpManagement.java
@@ -284,7 +284,7 @@ class AmqpManagement implements Management {
                 this.receiveLoop = null;
               }
               LOGGER.debug("Creating management session ({}).", this);
-              this.session = this.connection.nativeConnection().openSession();
+              this.session = this.connection.nativeConnection().openSession(Utils.sessionOptions());
               String linkPairName = "management-link-pair";
               Map<String, Object> properties = Collections.singletonMap("paired", Boolean.TRUE);
               LOGGER.debug("Creating management sender ({}).", this);

--- a/src/main/java/com/rabbitmq/client/amqp/impl/SessionHandler.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/SessionHandler.java
@@ -70,7 +70,7 @@ interface SessionHandler extends AutoCloseable {
     public Session session() {
       closeCurrentSession();
       try {
-        Session session = this.connection.get().openSession();
+        Session session = this.connection.get().openSession(Utils.sessionOptions());
         this.session.set(ExceptionUtils.wrapGet(session.openFuture()));
         return this.session.get();
       } catch (ClientException e) {

--- a/src/main/java/com/rabbitmq/client/amqp/impl/Utils.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/Utils.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
+import org.apache.qpid.protonj2.client.SessionOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,6 +104,10 @@ final class Utils {
   }
 
   private Utils() {}
+
+  static SessionOptions sessionOptions() {
+    return new SessionOptions().incomingCapacity(0);
+  }
 
   static ExecutorService executorService(String prefixFormat, Object... args) {
     return EXECUTOR_SERVICE_FACTORY.apply(String.format(prefixFormat, args));


### PR DESCRIPTION
This commits "blocks" the incoming to Integer.MAX_VALUE by setting the session incoming capacity to 0. Previously the incoming window was calculated dynamically based on in-flight transfer frame size and the max frame size. This could result in "small" window size (e.g. 1600) that would limit traffic for consumers that set up a large initial credit value.

By setting a large incoming window, we let receiver links handle the flow with credits, favoring link flow control over session flow control.

References #316