### PR TITLE
Fix EventLoop task exception handling and robustness issues

### DIFF
--- a/src/main/java/com/rabbitmq/client/amqp/impl/EventLoop.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/EventLoop.java
@@ -61,22 +61,23 @@ final class EventLoop implements AutoCloseable {
                 try {
                   ClientTaskContext<?> context = this.taskQueue.poll(1000, TimeUnit.MILLISECONDS);
                   if (context != null) {
-                    if (context.registration) {
-                      context.task.apply(null);
-                      activeClients.put(context.client.id, context.client.stateReference.get());
+                    try {
+                      if (context.registration) {
+                        context.task.apply(null);
+                        activeClients.put(context.client.id, context.client.stateReference.get());
+                        continue;
+                      }
+                      Object clientState = activeClients.get(context.client.id);
+                      if (clientState == null) {
+                        continue;
+                      }
+                      TaskResult result = context.task.apply(clientState);
+                      if (result == TaskResult.STOP) {
+                        activeClients.remove(context.client.id);
+                      }
+                    } finally {
                       context.complete();
-                      continue;
                     }
-                    Object clientState = activeClients.get(context.client.id);
-                    if (clientState == null) {
-                      context.complete();
-                      continue;
-                    }
-                    TaskResult result = context.task.apply(clientState);
-                    if (result == TaskResult.STOP) {
-                      activeClients.remove(context.client.id);
-                    }
-                    context.complete();
                   }
                 } catch (InterruptedException e) {
                   LOGGER.debug("Event loop has been interrupted.");
@@ -141,10 +142,12 @@ final class EventLoop implements AutoCloseable {
       throw new IllegalStateException("Event loop is closed");
     }
     if (Thread.currentThread().equals(this.loopThread.get())) {
-      try {
-        task.apply(client.stateReference.get());
-      } catch (Exception e) {
-        LOGGER.warn("Error during task", e);
+      if (!client.closed.get()) {
+        try {
+          task.apply(client.stateReference.get());
+        } catch (Exception e) {
+          LOGGER.warn("Error during task", e);
+        }
       }
     } else {
       CountDownLatch latch = new CountDownLatch(1);
@@ -235,29 +238,23 @@ final class EventLoop implements AutoCloseable {
     // for testing
     <R> R query(Function<S, R> queryFunction) {
       AtomicReference<R> result = new AtomicReference<>();
-      CountDownLatch latch = new CountDownLatch(1);
-
-      // Submit a task that extracts data from the state
       this.loop.submit(
           this,
           s -> {
             result.set(queryFunction.apply(s));
-            latch.countDown();
             return TaskResult.CONTINUE;
           });
-
-      try {
-        latch.await(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
       return result.get();
     }
 
     @Override
     public void close() {
       if (this.closed.compareAndSet(false, true)) {
-        this.loop.submit(this, s -> TaskResult.STOP);
+        try {
+          this.loop.submit(this, s -> TaskResult.STOP);
+        } catch (IllegalStateException e) {
+          // event loop already closed
+        }
       }
     }
   }

--- a/src/test/java/com/rabbitmq/client/amqp/impl/EventLoopTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/EventLoopTest.java
@@ -18,30 +18,25 @@
 package com.rabbitmq.client.amqp.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class EventLoopTest {
 
-  static ExecutorService executorService;
+  ExecutorService executorService;
   EventLoop loop;
   EventLoop.Client<State> client;
 
-  @BeforeAll
-  static void beforeAll() {
-    executorService = Executors.newSingleThreadExecutor();
-  }
-
   @BeforeEach
   void beforeEach() {
+    executorService = Executors.newSingleThreadExecutor();
     loop = new EventLoop(executorService);
     client = loop.register(State::new);
   }
@@ -49,10 +44,6 @@ public class EventLoopTest {
   @AfterEach
   void afterEach() {
     loop.close();
-  }
-
-  @AfterAll
-  static void afterAll() {
     executorService.shutdownNow();
   }
 
@@ -80,6 +71,23 @@ public class EventLoopTest {
     assertThatThrownBy(() -> client.submit(s -> {})).isInstanceOf(IllegalStateException.class);
     loop.close();
     assertThatThrownBy(() -> loop.register(State::new)).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void taskThrowingExceptionUnblocksCallerAndLoopContinues() {
+    AtomicInteger buffer = new AtomicInteger();
+    client.submit(
+        s -> {
+          throw new RuntimeException("task failure (expected test failure)");
+        });
+    client.submit(s -> buffer.set(42));
+    assertThat(buffer).hasValue(42);
+  }
+
+  @Test
+  void closingClientAfterLoopCloseDoesNotThrow() {
+    loop.close();
+    assertThatCode(() -> client.close()).doesNotThrowAnyException();
   }
 
   static class State {


### PR DESCRIPTION
- Wrap task execution in try/finally to guarantee context.complete() is always called
- Remove redundant CountDownLatch from Client.query() method
- Handle IllegalStateException in Client.close() when EventLoop is already closed
- Add client.closed check in the in-loop fast path of submit()
- Add tests for task exception handling and client close after loop close
- Use per-test executor in EventLoopTest to avoid thread state bleeding