### PR TITLE
Propagate rejection description in exception message

### DIFF
--- a/src/main/java/com/rabbitmq/client/amqp/AmqpException.java
+++ b/src/main/java/com/rabbitmq/client/amqp/AmqpException.java
@@ -91,4 +91,16 @@ public class AmqpException extends RuntimeException {
       super(message, cause);
     }
   }
+
+  /**
+   * Exception thrown when a message is rejected by the broker.
+   *
+   * @since 1.1.0
+   */
+  public static class AmqpMessageRejectedException extends AmqpException {
+
+    public AmqpMessageRejectedException(String message) {
+      super(message);
+    }
+  }
 }

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpPublisher.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpPublisher.java
@@ -18,6 +18,7 @@
 package com.rabbitmq.client.amqp.impl;
 
 import static com.rabbitmq.client.amqp.Resource.State.OPEN;
+import static com.rabbitmq.client.amqp.impl.AmqpUtils.mapToPublishDisposition;
 import static com.rabbitmq.client.amqp.impl.Utils.maybeClose;
 
 import com.rabbitmq.client.amqp.Message;
@@ -132,7 +133,9 @@ final class AmqpPublisher extends ResourceBase implements Publisher {
             (t, ex) -> {
               Status status;
               if (ex == null) {
-                status = mapDeliveryState(t.remoteState());
+                DeliveryState remoteDelState = t.remoteState();
+                status = AmqpUtils.mapDeliveryState(remoteDelState);
+                ex = AmqpUtils.maybeMapToRejectedException(remoteDelState);
               } else {
                 status = Status.REJECTED;
               }
@@ -145,34 +148,9 @@ final class AmqpPublisher extends ResourceBase implements Publisher {
     this.metricsCollector.publish();
   }
 
-  private Status mapDeliveryState(DeliveryState in) {
-    if (in.isAccepted()) {
-      return Status.ACCEPTED;
-    } else if (in.getType() == DeliveryState.Type.REJECTED) {
-      return Status.REJECTED;
-    } else if (in.getType() == DeliveryState.Type.RELEASED) {
-      return Status.RELEASED;
-    } else {
-      LOGGER.warn("Delivery state not supported: " + in.getType());
-      throw new IllegalStateException("This delivery state is not supported: " + in.getType());
-    }
-  }
-
   private Tracker doSend(AmqpMessage msg) throws ClientException {
     msg.enforceDurability();
     return this.sender.send(msg.nativeMessage());
-  }
-
-  private static MetricsCollector.PublishDisposition mapToPublishDisposition(Status status) {
-    if (status == Status.ACCEPTED) {
-      return MetricsCollector.PublishDisposition.ACCEPTED;
-    } else if (status == Status.REJECTED) {
-      return MetricsCollector.PublishDisposition.REJECTED;
-    } else if (status == Status.RELEASED) {
-      return MetricsCollector.PublishDisposition.RELEASED;
-    } else {
-      return null;
-    }
   }
 
   void recoverAfterConnectionFailure() {

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpUtils.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpUtils.java
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+package com.rabbitmq.client.amqp.impl;
+
+import com.rabbitmq.client.amqp.AmqpException;
+import com.rabbitmq.client.amqp.Publisher;
+import com.rabbitmq.client.amqp.metrics.MetricsCollector;
+import org.apache.qpid.protonj2.client.DeliveryState;
+import org.apache.qpid.protonj2.client.Rejected;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class AmqpUtils {
+
+  static final String INFO_FIELD_QUEUE = "queue";
+  static final String INFO_FIELD_REASON = "reason";
+  static final String INFO_FIELD_REASON_MAX_LENGTH = "maxlen";
+  static final String INFO_FIELD_REASON_UNAVAILABLE = "unavailable";
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AmqpUtils.class);
+
+  private AmqpUtils() {}
+
+  static Publisher.Status mapDeliveryState(DeliveryState in) {
+    if (in.isAccepted()) {
+      return Publisher.Status.ACCEPTED;
+    } else if (in.getType() == DeliveryState.Type.REJECTED) {
+      return Publisher.Status.REJECTED;
+    } else if (in.getType() == DeliveryState.Type.RELEASED) {
+      return Publisher.Status.RELEASED;
+    } else {
+      LOGGER.warn("Delivery state not supported: " + in.getType());
+      throw new IllegalStateException("This delivery state is not supported: " + in.getType());
+    }
+  }
+
+  static Throwable maybeMapToRejectedException(DeliveryState deliveryState) {
+    Throwable result = null;
+    if (deliveryState instanceof Rejected) {
+      Rejected rejected = (Rejected) deliveryState;
+      result =
+          new AmqpException.AmqpMessageRejectedException(
+              rejected.getDescription() == null
+                  ? "Message has been rejected"
+                  : rejected.getDescription());
+    }
+    return result;
+  }
+
+  static MetricsCollector.PublishDisposition mapToPublishDisposition(Publisher.Status status) {
+    if (status == Publisher.Status.ACCEPTED) {
+      return MetricsCollector.PublishDisposition.ACCEPTED;
+    } else if (status == Publisher.Status.REJECTED) {
+      return MetricsCollector.PublishDisposition.REJECTED;
+    } else if (status == Publisher.Status.RELEASED) {
+      return MetricsCollector.PublishDisposition.RELEASED;
+    } else {
+      return null;
+    }
+  }
+}

--- a/src/test/java/com/rabbitmq/client/amqp/impl/AmqpTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/AmqpTest.java
@@ -19,6 +19,7 @@ package com.rabbitmq.client.amqp.impl;
 
 import static com.rabbitmq.client.amqp.Management.ExchangeType.DIRECT;
 import static com.rabbitmq.client.amqp.Management.ExchangeType.FANOUT;
+import static com.rabbitmq.client.amqp.Management.OverflowStrategy.REJECT_PUBLISH;
 import static com.rabbitmq.client.amqp.Management.QueueType.CLASSIC;
 import static com.rabbitmq.client.amqp.Management.QueueType.QUORUM;
 import static com.rabbitmq.client.amqp.Management.QueueType.STREAM;
@@ -41,6 +42,7 @@ import static org.assertj.core.api.Fail.fail;
 
 import com.rabbitmq.client.amqp.AmqpException;
 import com.rabbitmq.client.amqp.AmqpException.AmqpEntityDoesNotExistException;
+import com.rabbitmq.client.amqp.AmqpException.AmqpMessageRejectedException;
 import com.rabbitmq.client.amqp.AmqpException.AmqpResourceInvalidStateException;
 import com.rabbitmq.client.amqp.Connection;
 import com.rabbitmq.client.amqp.Consumer;
@@ -82,6 +84,7 @@ public class AmqpTest {
   Connection connection;
   Environment environment;
   String name;
+  String brokerVersion;
 
   private static String uuid() {
     return UUID.randomUUID().toString();
@@ -791,15 +794,13 @@ public class AmqpTest {
     String q = TestUtils.name(info);
     int maxLength = 10;
     try {
-      management
-          .queue(q)
-          .maxLength(maxLength)
-          .overflowStrategy(Management.OverflowStrategy.REJECT_PUBLISH)
-          .declare();
+      management.queue(q).maxLength(maxLength).overflowStrategy(REJECT_PUBLISH).declare();
       CountDownLatch rejectedLatch = new CountDownLatch(1);
+      AtomicReference<Throwable> exception = new AtomicReference<>();
       Publisher.Callback callback =
           context -> {
             if (context.status() == Publisher.Status.REJECTED) {
+              exception.set(context.failureCause());
               rejectedLatch.countDown();
             }
           };
@@ -807,6 +808,14 @@ public class AmqpTest {
       IntStream.range(0, maxLength + 1)
           .forEach(ignored -> publisher.publish(publisher.message(), callback));
       assertThat(rejectedLatch).completes();
+      if (TestUtils.atLeastVersion("4.3.0", this.brokerVersion)) {
+        assertThat(exception.get())
+            .isNotNull()
+            .isInstanceOf(AmqpMessageRejectedException.class)
+            .hasMessageContaining(q)
+            .hasMessageContaining("exceeded")
+            .hasMessageContaining("length");
+      }
     } finally {
       management.queueDelete(q);
     }


### PR DESCRIPTION
Add an AmqpMessageRejectedException to the published message callback
context in a case of a rejected message. The exception message contains the
string provided by the broker.

See https://www.rabbitmq.com/blog/2026/04/23/rabbitmq-4.3-release#amqp-rejection-reason

Fixes https://github.com/rabbitmq/rabbitmq-amqp-java-client/issues/378