### PR TITLE
Add body converter methods for non-binary AMQP message payloads

### DIFF
--- a/src/main/java/com/rabbitmq/client/amqp/Message.java
+++ b/src/main/java/com/rabbitmq/client/amqp/Message.java
@@ -19,6 +19,7 @@ package com.rabbitmq.client.amqp;
 
 import java.math.BigDecimal;
 import java.time.Duration;
+import java.util.List;
 import java.util.UUID;
 import java.util.function.BiConsumer;
 
@@ -585,11 +586,101 @@ public interface Message {
   Message body(byte[] body);
 
   /**
-   * Get the message body.
+   * Get the message body as bytes.
    *
-   * @return the message body
+   * <p>This is a convenience API for byte-oriented payload access. It is intended for message
+   * bodies that can be represented as a byte array, such as Data sections and compatible AmqpValue
+   * payloads (for example String values converted to UTF-8 bytes).
+   *
+   * <p>For AMQP body types that are not naturally byte-oriented, such as AmqpSequence or typed
+   * AmqpValue payloads, use {@link #body(Converter)} or {@link #body(SectionsConverter)}.
+   *
+   * @return the message body as bytes
+   * @throws AmqpException if the body cannot be represented as bytes
    */
   byte[] body();
+
+  /**
+   * Get the message body converted using the specified converter.
+   *
+   * <p>This method provides access to the message body content in its native AMQP 1.0 format,
+   * allowing applications to handle non-binary payloads and complex message body structures.
+   * According to the <a
+   * href="https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#section-message-format">AMQP
+   * 1.0 message format specification</a>, a message body can contain various section types
+   * including AmqpValue, AmqpSequence, and Data sections.
+   *
+   * <p>This method extracts the value from the <strong>first body section only</strong> and passes
+   * it to the converter. For messages with multiple body sections, use {@link
+   * #body(SectionsConverter)} instead.
+   *
+   * <p>The converter input type must match the runtime type of the value exposed by the underlying
+   * AMQP implementation for the first body section. For example, applications may receive {@code
+   * byte[]}, {@code String}, {@code List<?>}, or implementation-specific AMQP types such as {@code
+   * Binary}.
+   *
+   * <p>If the converter expects a type that does not match the runtime body value type, a {@link
+   * ClassCastException} may be thrown by the converter invocation.
+   *
+   * <p><strong>Implementation Note:</strong> This method exposes values coming from the underlying
+   * AMQP implementation (currently Qpid Proton-J2). Applications using this API should treat these
+   * values as implementation-coupled runtime types rather than stable library-defined model types.
+   * Changes in the underlying implementation may affect the concrete runtime types observed by
+   * applications using this API.
+   *
+   * @param <I> the input type expected by the converter (the type of the body section value)
+   * @param <O> the output type returned by the converter
+   * @param converter the converter to transform the body section value
+   * @return the converted body value
+   * @throws AmqpException if an error occurs while accessing the message body
+   * @see #body(SectionsConverter) for multi-section message bodies
+   * @see #body() for simple binary body access
+   */
+  <I, O> O body(Converter<I, O> converter);
+
+  /**
+   * Get the message body with access to all body sections using the specified sections converter.
+   *
+   * <p>This method provides complete access to multi-section message bodies as defined in the <a
+   * href="https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#section-message-format">AMQP
+   * 1.0 message format specification</a>. AMQP 1.0 messages can contain multiple body sections of
+   * the same type:
+   *
+   * <ul>
+   *   <li><strong>Multiple Data sections</strong> - Each containing binary data, typically
+   *       concatenated logically
+   *   <li><strong>Multiple AmqpSequence sections</strong> - Each containing a list of structured
+   *       values
+   *   <li><strong>Single AmqpValue section</strong> - Containing a single AMQP value of any type
+   * </ul>
+   *
+   * <p>The converter receives a list of all section values from the message body, allowing
+   * applications to process complex multi-section payloads that cannot be handled by the
+   * single-section {@link #body(Converter)} method.
+   *
+   * <p>The converter input type must match the runtime type of each section value exposed by the
+   * underlying AMQP implementation. All body sections in a valid AMQP message are expected to be of
+   * the same section kind, but applications should still treat the values as implementation exposed
+   * runtime objects.
+   *
+   * <p>If the converter expects a type that does not match the runtime section value type, a {@link
+   * ClassCastException} may be thrown by the converter invocation.
+   *
+   * <p><strong>Implementation Note:</strong> This method exposes values coming from the underlying
+   * AMQP implementation (currently Qpid Proton-J2). Applications using this API should treat these
+   * values as implementation-coupled runtime types rather than stable library-defined model types.
+   * Changes in the underlying implementation may affect the concrete runtime types observed by
+   * applications using this API.
+   *
+   * @param <I> the input type expected by the converter (the type of each body section value)
+   * @param <O> the output type returned by the converter
+   * @param converter the sections converter to transform all body section values
+   * @return the converted body value from all sections
+   * @throws AmqpException if an error occurs while accessing the message body sections
+   * @see #body(Converter) for single-section message bodies
+   * @see #body() for simple binary body access
+   */
+  <I, O> O body(SectionsConverter<I, O> converter);
 
   /**
    * Mark the message as durable or not.
@@ -748,5 +839,79 @@ public interface Message {
   interface MessageAddressBuilder extends AddressBuilder<MessageAddressBuilder> {
 
     Message message();
+  }
+
+  /**
+   * Functional interface for converting a single AMQP body section value.
+   *
+   * <p>This converter is used with {@link #body(Converter)} to transform the value from the first
+   * body section of an AMQP 1.0 message into a desired output type. The input type {@code I}
+   * corresponds to the native type of the body section value as exposed by
+   * the underlying AMQP implementation.
+   *
+   * <p><strong>Common Input Types:</strong>
+   *
+   * <ul>
+   *   <li>{@code byte[]} - for Data sections containing binary data
+   *   <li>{@code String} - for AmqpValue sections containing strings
+   *   <li>{@code List<?>} - for AmqpSequence sections containing lists
+   *   <li>Various AMQP types - for AmqpValue sections with typed content (Integer, UUID, Symbol,
+   *       etc.)
+   * </ul>
+   *
+   * @param <I> the input type (body section value type from the AMQP implementation)
+   * @param <O> the output type (application-specific converted type)
+   * @see #body(Converter)
+   */
+  @FunctionalInterface
+  interface Converter<I, O> {
+
+    /**
+     * Convert the given AMQP body section value to the desired output type.
+     *
+     * @param value the body section value from the AMQP message
+     * @return the converted value
+     */
+    O convert(I value);
+  }
+
+  /**
+   * Functional interface for converting multiple AMQP body section values.
+   *
+   * <p>This converter is used with {@link #body(SectionsConverter)} to process all body sections
+   * from an AMQP 1.0 message. According to the AMQP 1.0 specification, a message body can contain
+   * multiple sections of the same type, and this converter provides access to all of them.
+   *
+   * <p><strong>Multi-Section Scenarios:</strong>
+   *
+   * <ul>
+   *   <li><strong>Multiple Data sections</strong> - List of {@code byte[]} arrays, typically
+   *       concatenated
+   *   <li><strong>Multiple AmqpSequence sections</strong> - List of {@code List<?>} objects
+   *   <li><strong>Single AmqpValue section</strong> - List with one element of the AmqpValue type
+   * </ul>
+   *
+   * <p>The converter receives all section values as a list, allowing applications to aggregate,
+   * concatenate, or otherwise process complex multi-section message bodies that exceed the
+   * capabilities of single-section processing.
+   *
+   * @param <I> the input type (body section value type from the AMQP implementation)
+   * @param <O> the output type (application-specific converted type)
+   * @see #body(SectionsConverter)
+   */
+  @FunctionalInterface
+  interface SectionsConverter<I, O> {
+    /**
+     * Convert the given list of AMQP body section values to the desired output type.
+     *
+     * <p>The list contains all body sections from the message in their original order. For Data
+     * sections, this typically means multiple {@code byte[]} arrays. For AmqpSequence sections,
+     * this means multiple {@code List<?>} objects. For AmqpValue sections, this typically contains
+     * a single element.
+     *
+     * @param sections the list of body section values from the AMQP message
+     * @return the converted value
+     */
+    O convert(List<I> sections);
   }
 }

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpMessage.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpMessage.java
@@ -24,7 +24,10 @@ import com.rabbitmq.client.amqp.Message;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 import java.util.function.BiConsumer;
 import org.apache.qpid.protonj2.client.exceptions.ClientException;
@@ -38,6 +41,7 @@ import org.apache.qpid.protonj2.types.UnsignedInteger;
 import org.apache.qpid.protonj2.types.UnsignedLong;
 import org.apache.qpid.protonj2.types.UnsignedShort;
 import org.apache.qpid.protonj2.types.messaging.Data;
+import org.apache.qpid.protonj2.types.messaging.Section;
 
 final class AmqpMessage implements Message {
 
@@ -458,21 +462,55 @@ final class AmqpMessage implements Message {
     return this;
   }
 
+  private static final Message.Converter<Object, byte[]> DEFAULT_CONVERTER =
+      value -> {
+        if (value == null) {
+          return null;
+        } else if (value instanceof byte[]) {
+          return (byte[]) value;
+        } else if (value instanceof Binary) {
+          return ((Binary) value).asByteArray();
+        } else if (value instanceof String) {
+          return ((String) value).getBytes(StandardCharsets.UTF_8);
+        } else {
+          throw new AmqpException("Unsupported body type: " + value.getClass().getName());
+        }
+      };
+
   @Override
   public byte[] body() {
     try {
       Object value = this.delegate.body();
-      if (value == null) {
-        return null;
-      } else if (value instanceof byte[]) {
-        return (byte[]) value;
-      } else if (value instanceof Binary) {
-        return ((Binary) value).asByteArray();
-      } else if (value instanceof String) {
-        return ((String) value).getBytes(StandardCharsets.UTF_8);
-      } else {
-        throw new AmqpException("Unsupported body type: " + value.getClass().getName());
+      return DEFAULT_CONVERTER.convert(value);
+    } catch (ClientException e) {
+      throw convert(e);
+    }
+  }
+
+  @Override
+  public <I, O> O body(Converter<I, O> converter) {
+    try {
+      @SuppressWarnings("unchecked")
+      I value = (I) this.delegate.body();
+      return converter.convert(value);
+    } catch (ClientException e) {
+      throw convert(e);
+    }
+  }
+
+  @Override
+  public <I, O> O body(SectionsConverter<I, O> converter) {
+    try {
+      Collection<Section<?>> sections = this.delegate.toAdvancedMessage().bodySections();
+      List<I> sectionValues = new ArrayList<>(sections.size());
+
+      for (Section<?> section : sections) {
+        @SuppressWarnings("unchecked")
+        I value = (I) section.getValue();
+        sectionValues.add(value);
       }
+
+      return converter.convert(sectionValues);
     } catch (ClientException e) {
       throw convert(e);
     }

--- a/src/main/java/com/rabbitmq/client/amqp/impl/Tuples.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/Tuples.java
@@ -21,11 +21,15 @@ final class Tuples {
 
   private Tuples() {}
 
-  public static <A, B> Pair<A, B> pair(A v1, B v2) {
+  static <A, B> Pair<A, B> pair(A v1, B v2) {
     return new Pair<>(v1, v2);
   }
 
-  public static class Pair<A, B> {
+  static <A, B, C> Triple<A, B, C> triple(A v1, B v2, C v3) {
+    return new Triple<>(v1, v2, v3);
+  }
+
+  static class Pair<A, B> {
 
     private final A v1;
     private final B v2;
@@ -35,12 +39,37 @@ final class Tuples {
       this.v2 = v2;
     }
 
-    public A v1() {
+    A v1() {
       return this.v1;
     }
 
-    public B v2() {
+    B v2() {
       return this.v2;
+    }
+  }
+
+  static class Triple<A, B, C> {
+
+    private final A v1;
+    private final B v2;
+    private final C v3;
+
+    private Triple(A v1, B v2, C v3) {
+      this.v1 = v1;
+      this.v2 = v2;
+      this.v3 = v3;
+    }
+
+    A v1() {
+      return this.v1;
+    }
+
+    B v2() {
+      return this.v2;
+    }
+
+    C v3() {
+      return this.v3;
     }
   }
 }

--- a/src/test/java/com/rabbitmq/client/amqp/impl/AmqpMessageTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/AmqpMessageTest.java
@@ -17,19 +17,39 @@
 // info@rabbitmq.com.
 package com.rabbitmq.client.amqp.impl;
 
+import static com.rabbitmq.client.amqp.impl.Tuples.triple;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.rabbitmq.client.amqp.AmqpException;
+import com.rabbitmq.client.amqp.Message;
+import com.rabbitmq.client.amqp.impl.Tuples.Triple;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import org.apache.qpid.protonj2.buffer.ProtonBuffer;
 import org.apache.qpid.protonj2.buffer.ProtonBufferAllocator;
 import org.apache.qpid.protonj2.client.impl.ClientMessageSupport;
 import org.apache.qpid.protonj2.codec.CodecFactory;
 import org.apache.qpid.protonj2.codec.Encoder;
 import org.apache.qpid.protonj2.types.Binary;
+import org.apache.qpid.protonj2.types.Symbol;
+import org.apache.qpid.protonj2.types.UnsignedByte;
+import org.apache.qpid.protonj2.types.UnsignedInteger;
+import org.apache.qpid.protonj2.types.UnsignedLong;
+import org.apache.qpid.protonj2.types.UnsignedShort;
+import org.apache.qpid.protonj2.types.messaging.AmqpSequence;
 import org.apache.qpid.protonj2.types.messaging.AmqpValue;
+import org.apache.qpid.protonj2.types.messaging.Data;
 import org.junit.jupiter.api.Test;
 
 public class AmqpMessageTest {
+
+  private static AmqpMessage msg() {
+    return new AmqpMessage();
+  }
 
   @Test
   void toShouldBePathEncoded() {
@@ -84,7 +104,287 @@ public class AmqpMessageTest {
     }
   }
 
-  private static AmqpMessage msg() {
-    return new AmqpMessage();
+  @Test
+  void bodyConverterShouldExposeFirstBodySectionValue() throws Exception {
+    Encoder encoder = CodecFactory.getDefaultEncoder();
+
+    List<Triple<Object, Message.Converter<?, ?>, Object>> testCases =
+        List.of(
+            // Supported types by default converter
+            triple(new AmqpValue<>("hello world"), Object::toString, "hello world"),
+
+            // AmqpValue with various AMQP 1.0 types that should fail with default converter
+            triple(new AmqpValue<>(42), (Integer i) -> i.toString(), "42"),
+            triple(new AmqpValue<>(3.14159), (Double d) -> String.format("%.5f", d), "3.14159"),
+            triple(new AmqpValue<>(true), (Boolean b) -> b ? "TRUE" : "FALSE", "TRUE"),
+            triple(new AmqpValue<>(true), (Boolean b) -> b, Boolean.TRUE),
+            triple(
+                new AmqpValue<>(UUID.fromString("123e4567-e89b-12d3-a456-426614174000")),
+                (UUID uuid) -> uuid.toString().toUpperCase(),
+                "123E4567-E89B-12D3-A456-426614174000"),
+            triple(
+                new AmqpValue<>(1640995200000L),
+                (Long timestamp) -> Long.toString(timestamp),
+                "1640995200000"),
+            triple(
+                new AmqpValue<>(Symbol.getSymbol("test-symbol")),
+                (Symbol symbol) -> symbol.toString(),
+                "test-symbol"),
+            triple(
+                new AmqpValue<>(new UnsignedByte((byte) 255)),
+                (UnsignedByte ub) -> ub.toString(),
+                "255"),
+            triple(
+                new AmqpValue<>(new UnsignedShort((short) 32767)),
+                (UnsignedShort us) -> us.toString(),
+                "32767"),
+            triple(
+                new AmqpValue<>(new UnsignedInteger(2147483647)),
+                (UnsignedInteger ui) -> ui.toString(),
+                "2147483647"),
+            triple(
+                new AmqpValue<>(UnsignedLong.valueOf("18446744073709551615")),
+                (UnsignedLong ul) -> ul.toString(),
+                "18446744073709551615"),
+            triple(new AmqpValue<>('X'), (Character c) -> c.toString(), "X"),
+            triple(
+                new AmqpValue<>(Arrays.asList("item1", "item2", "item3")),
+                (List<?> list) -> String.join(",", (CharSequence[]) list.toArray(new String[0])),
+                "item1,item2,item3"),
+            triple(
+                new AmqpValue<>(Map.of("key1", "value1", "key2", "value2")),
+                (Map<?, ?> map) -> "map with " + map.size() + " entries",
+                "map with 2 entries"),
+
+            // AmqpSequence with various content types
+            triple(
+                new AmqpSequence<>(Arrays.asList("seq1", "seq2", "seq3")),
+                (List<?> seq) -> String.join("|", (CharSequence[]) seq.toArray(new String[0])),
+                "seq1|seq2|seq3"),
+            triple(
+                new AmqpSequence<>(Arrays.asList(1, 2, 3, 4, 5)),
+                (List<?> seq) -> seq.stream().mapToInt(i -> (Integer) i).sum() + "",
+                "15"),
+            triple(
+                new AmqpSequence<>(Arrays.asList(Map.of("name", "Alice"), Map.of("name", "Bob"))),
+                (List<?> seq) -> seq.size() + " items",
+                "2 items"),
+
+            // Data sections (single)
+            triple(
+                new Data(new byte[] {1, 2, 3, 4, 5}),
+                (byte[] data) -> Arrays.toString(data),
+                "[1, 2, 3, 4, 5]"),
+            triple(
+                new Data("test data".getBytes(StandardCharsets.UTF_8)),
+                (byte[] data) -> new String(data, StandardCharsets.UTF_8),
+                "test data"));
+
+    for (Triple<Object, Message.Converter<?, ?>, Object> testCase : testCases) {
+      try (ProtonBuffer buffer = ProtonBufferAllocator.defaultAllocator().allocate(256)) {
+        Object body = testCase.v1();
+        Message.Converter<?, ?> converter = testCase.v2();
+        Object expected = testCase.v3();
+        encoder.writeObject(buffer, encoder.newEncoderState(), body);
+        org.apache.qpid.protonj2.client.Message<?> decoded =
+            ClientMessageSupport.decodeMessage(buffer, null);
+        AmqpMessage message = new AmqpMessage(decoded);
+        assertThat(message.body(converter)).isEqualTo(expected);
+      }
+    }
+  }
+
+  @Test
+  void defaultConverterShouldFailOnUnsupportedTypes() throws Exception {
+    Encoder encoder = CodecFactory.getDefaultEncoder();
+
+    // Test various AMQP 1.0 types that should fail with the default converter
+    Object[] unsupportedPayloads = {
+      new AmqpValue<>(42),
+      new AmqpValue<>(3.14159),
+      new AmqpValue<>(true),
+      new AmqpValue<>(UUID.randomUUID()),
+      new AmqpValue<>(System.currentTimeMillis()),
+      new AmqpValue<>(Symbol.getSymbol("test")),
+      new AmqpValue<>(new UnsignedByte((byte) 255)),
+      new AmqpValue<>(new UnsignedShort((short) 32767)),
+      new AmqpValue<>(new UnsignedInteger(2147483647)),
+      new AmqpValue<>(UnsignedLong.MAX_VALUE),
+      new AmqpValue<>('X'),
+      new AmqpValue<>(Arrays.asList("item1", "item2")),
+      new AmqpValue<>(Map.of("key", "value")),
+      new AmqpSequence<>(Arrays.asList("seq1", "seq2")),
+      new AmqpSequence<>(Arrays.asList(1, 2, 3))
+    };
+
+    for (Object payload : unsupportedPayloads) {
+      try (ProtonBuffer buffer = ProtonBufferAllocator.defaultAllocator().allocate(256)) {
+        encoder.writeObject(buffer, encoder.newEncoderState(), payload);
+        org.apache.qpid.protonj2.client.Message<?> decoded =
+            ClientMessageSupport.decodeMessage(buffer, null);
+        AmqpMessage message = new AmqpMessage(decoded);
+
+        assertThatThrownBy(message::body)
+            .isInstanceOf(AmqpException.class)
+            .hasMessageContaining("Unsupported body type:");
+      }
+    }
+  }
+
+  @Test
+  void messageWithMultiSectionsShouldGetOnlyFirstSection() throws Exception {
+    // Create a message with multiple Data sections
+    org.apache.qpid.protonj2.client.Message<?> nativeMessage =
+        org.apache.qpid.protonj2.client.Message.create();
+
+    nativeMessage.toAdvancedMessage().clearBodySections();
+    nativeMessage
+        .toAdvancedMessage()
+        .addBodySection(new Data("First ".getBytes(StandardCharsets.UTF_8)));
+    nativeMessage
+        .toAdvancedMessage()
+        .addBodySection(new Data("Second ".getBytes(StandardCharsets.UTF_8)));
+    nativeMessage
+        .toAdvancedMessage()
+        .addBodySection(new Data("Third".getBytes(StandardCharsets.UTF_8)));
+
+    AmqpMessage message = new AmqpMessage(nativeMessage);
+
+    // The default body() method should only return the first section
+    assertThat(message.body()).isEqualTo("First ".getBytes(StandardCharsets.UTF_8));
+
+    // Access all sections via converter
+    assertThat(
+            message.body(
+                (Object body) -> {
+                  // body(Converter) delegates to the underlying single-body view and therefore
+                  // observes only the first body section when multiple sections are present.
+                  return new String((byte[]) body, StandardCharsets.UTF_8);
+                }))
+        .isEqualTo("First ");
+  }
+
+  @Test
+  void multipleAmqpSequenceSectionsShouldGetOnlyFirstSequence() throws Exception {
+    Encoder encoder = CodecFactory.getDefaultEncoder();
+
+    try (ProtonBuffer buffer = ProtonBufferAllocator.defaultAllocator().allocate(1024)) {
+      // Encode multiple AmqpSequence sections
+      encoder.writeObject(
+          buffer,
+          encoder.newEncoderState(),
+          new AmqpSequence<>(Arrays.asList("first", "sequence")));
+      encoder.writeObject(
+          buffer,
+          encoder.newEncoderState(),
+          new AmqpSequence<>(Arrays.asList("second", "sequence")));
+
+      org.apache.qpid.protonj2.client.Message<?> decoded =
+          ClientMessageSupport.decodeMessage(buffer, null);
+      AmqpMessage message = new AmqpMessage(decoded);
+
+      // Access the first sequence
+      assertThat(message.body((List<?> seq) -> seq.size())).isEqualTo(2);
+      assertThat(message.body((List<?> seq) -> seq.get(0))).isEqualTo("first");
+    }
+  }
+
+  @Test
+  void bodySectionsConverterShouldExposeAllBodySections() throws Exception {
+    Encoder encoder = CodecFactory.getDefaultEncoder();
+
+    List<Triple<Object, Message.SectionsConverter<?, ?>, Object>> testCases =
+        List.of(
+            // Single Data section
+            triple(
+                new Data("single data".getBytes(StandardCharsets.UTF_8)),
+                (List<byte[]> sections) -> sections.size() + " data section(s)",
+                "1 data section(s)"),
+
+            // Multiple Data sections
+            triple(
+                Arrays.asList(
+                    new Data("first ".getBytes(StandardCharsets.UTF_8)),
+                    new Data("second ".getBytes(StandardCharsets.UTF_8)),
+                    new Data("third".getBytes(StandardCharsets.UTF_8))),
+                (List<byte[]> sections) ->
+                    sections.stream()
+                        .map(data -> new String(data, StandardCharsets.UTF_8))
+                        .collect(java.util.stream.Collectors.joining()),
+                "first second third"),
+
+            // Single AmqpSequence section with strings
+            triple(
+                new AmqpSequence<>(Arrays.asList("hello", "world", "test")),
+                (List<List<String>> sections) -> sections.get(0).size() + " items in sequence",
+                "3 items in sequence"),
+
+            // Multiple AmqpSequence sections
+            triple(
+                Arrays.asList(
+                    new AmqpSequence<>(Arrays.asList("seq1", "item1")),
+                    new AmqpSequence<>(Arrays.asList("seq2", "item2", "item3"))),
+                (List<List<String>> sections) ->
+                    sections.stream().mapToInt(List::size).sum()
+                        + " total items across "
+                        + sections.size()
+                        + " sequences",
+                "5 total items across 2 sequences"),
+
+            // Single AmqpValue with String
+            triple(
+                new AmqpValue<>("hello from amqp value"),
+                (List<String> sections) -> "AmqpValue: " + sections.get(0),
+                "AmqpValue: hello from amqp value"),
+
+            // Single AmqpValue with byte array
+            triple(
+                new AmqpValue<>(new Binary("binary data".getBytes(StandardCharsets.UTF_8))),
+                (List<Binary> sections) -> "Binary length: " + sections.get(0).getLength(),
+                "Binary length: 11"));
+
+    for (Triple<Object, Message.SectionsConverter<?, ?>, Object> testCase : testCases) {
+      try (ProtonBuffer buffer = ProtonBufferAllocator.defaultAllocator().allocate(1024)) {
+        Object payload = testCase.v1();
+        Message.SectionsConverter<?, ?> converter = testCase.v2();
+        Object expected = testCase.v3();
+
+        if (payload instanceof java.util.List) {
+          // Multiple sections case
+          @SuppressWarnings("unchecked")
+          List<Object> sections = (List<Object>) payload;
+          for (Object section : sections) {
+            encoder.writeObject(buffer, encoder.newEncoderState(), section);
+          }
+        } else {
+          // Single section case
+          encoder.writeObject(buffer, encoder.newEncoderState(), payload);
+        }
+
+        org.apache.qpid.protonj2.client.Message<?> decoded =
+            ClientMessageSupport.decodeMessage(buffer, null);
+        AmqpMessage message = new AmqpMessage(decoded);
+        assertThat(message.body(converter)).isEqualTo(expected);
+      }
+    }
+  }
+
+  @Test
+  void bodySectionsConverterShouldReceiveEmptyListWhenMessageHasNoBodySections() throws Exception {
+    org.apache.qpid.protonj2.client.Message<?> nativeMessage =
+        org.apache.qpid.protonj2.client.Message.create();
+
+    nativeMessage.toAdvancedMessage().clearBodySections();
+
+    AmqpMessage message = new AmqpMessage(nativeMessage);
+
+    assertThat(message.body((List<Object> sections) -> sections)).isEmpty();
+  }
+
+  @Test
+  void bodyConverterShouldReceiveNullWhenMessageHasNoBody() {
+    AmqpMessage message = new AmqpMessage(org.apache.qpid.protonj2.client.Message.create());
+
+    assertThat(message.body((Object body) -> body)).isNull();
   }
 }


### PR DESCRIPTION
Add two new methods to Message for handling non-binary and multi-section
AMQP 1.0 message bodies:

- body(Converter<I, O>) for converting the first body section value
- body(SectionsConverter<I, O>) for processing all body sections

Keep body() as the existing byte-oriented convenience API.

This change makes it possible to read AmqpValue, AmqpSequence, and
multi-section Data payloads without changing the current byte[] contract
of body().

Fixes #388

API note: the Message interface now defines two additional body conversion
methods, body(Converter) and body(SectionsConverter). Custom third-party
implementations of Message must implement these methods.