### PR TITLE
Make Netty Codec HTTP module an optional dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
             <version>${netty4.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>


### PR DESCRIPTION
Used only for WebSocket support.