### PR TITLE
Enforce maximum message size on client side

### DIFF
--- a/src/main/java/com/rabbitmq/client/amqp/AmqpException.java
+++ b/src/main/java/com/rabbitmq/client/amqp/AmqpException.java
@@ -103,4 +103,27 @@ public class AmqpException extends RuntimeException {
       super(message);
     }
   }
+
+  /**
+   * Exception thrown when a message is invalid or violates message format constraints.
+   *
+   * <p>This exception is typically thrown when:
+   *
+   * <ul>
+   *   <li>A message exceeds the maximum allowed message size configured on the broker
+   *   <li>A message has an invalid format or structure
+   *   <li>A message violates broker-specific validation rules
+   * </ul>
+   *
+   * <p>Unlike other AMQP exceptions, this exception is often thrown on the client side before the
+   * message is sent to the broker, preventing connection or link closure that would occur if the
+   * broker rejected the message.
+   *
+   * @since 1.1.0
+   */
+  public static class AmqpInvalidMessageException extends AmqpException {
+    public AmqpInvalidMessageException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
 }

--- a/src/main/java/com/rabbitmq/client/amqp/Message.java
+++ b/src/main/java/com/rabbitmq/client/amqp/Message.java
@@ -846,8 +846,8 @@ public interface Message {
    *
    * <p>This converter is used with {@link #body(Converter)} to transform the value from the first
    * body section of an AMQP 1.0 message into a desired output type. The input type {@code I}
-   * corresponds to the native type of the body section value as exposed by
-   * the underlying AMQP implementation.
+   * corresponds to the native type of the body section value as exposed by the underlying AMQP
+   * implementation.
    *
    * <p><strong>Common Input Types:</strong>
    *

--- a/src/main/java/com/rabbitmq/client/amqp/impl/ExceptionUtils.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/ExceptionUtils.java
@@ -27,6 +27,7 @@ import org.apache.qpid.protonj2.client.exceptions.ClientConnectionRemotelyClosed
 import org.apache.qpid.protonj2.client.exceptions.ClientConnectionSecurityException;
 import org.apache.qpid.protonj2.client.exceptions.ClientException;
 import org.apache.qpid.protonj2.client.exceptions.ClientLinkRemotelyClosedException;
+import org.apache.qpid.protonj2.client.exceptions.ClientMessageFormatViolationException;
 import org.apache.qpid.protonj2.client.exceptions.ClientResourceRemotelyClosedException;
 import org.apache.qpid.protonj2.client.exceptions.ClientSessionRemotelyClosedException;
 
@@ -110,6 +111,8 @@ abstract class ExceptionUtils {
       } else {
         result = new AmqpException(e.getMessage(), e);
       }
+    } else if (e instanceof ClientMessageFormatViolationException) {
+      result = new AmqpException.AmqpInvalidMessageException(e.getMessage(), e);
     } else {
       result = new AmqpException(message, e);
     }

--- a/src/main/qpid/org/apache/qpid/protonj2/client/impl/ClientSender.java
+++ b/src/main/qpid/org/apache/qpid/protonj2/client/impl/ClientSender.java
@@ -32,6 +32,7 @@ import org.apache.qpid.protonj2.client.SenderOptions;
 import org.apache.qpid.protonj2.client.Tracker;
 import org.apache.qpid.protonj2.client.exceptions.ClientConnectionRemotelyClosedException;
 import org.apache.qpid.protonj2.client.exceptions.ClientException;
+import org.apache.qpid.protonj2.client.exceptions.ClientMessageFormatViolationException;
 import org.apache.qpid.protonj2.client.exceptions.ClientResourceRemotelyClosedException;
 import org.apache.qpid.protonj2.client.exceptions.ClientSendTimedOutException;
 import org.apache.qpid.protonj2.client.futures.ClientFuture;
@@ -51,6 +52,7 @@ public final class ClientSender extends ClientSenderLinkType<Sender> implements 
     private final Deque<ClientOutgoingEnvelope> blocked = new ArrayDeque<>();
     private final SenderOptions options;
     private final Consumer<ClientException> closeHandler;
+    private volatile long remoteMaxMessageSize = 0;
 
     ClientSender(ClientSession session, SenderOptions options, String senderId, org.apache.qpid.protonj2.engine.Sender protonSender) {
         super(session, senderId, options, protonSender);
@@ -157,6 +159,11 @@ public final class ClientSender extends ClientSenderLinkType<Sender> implements 
         final ClientFuture<Tracker> operation = session.getFutureFactory().createFuture();
         final ProtonBuffer buffer = message.encode(deliveryAnnotations, ProtonBufferAllocator.defaultAllocator());
 
+        if (this.remoteMaxMessageSize > 0 && buffer.getReadableBytes() > this.remoteMaxMessageSize) {
+            buffer.close();
+            throw new ClientMessageFormatViolationException("Message size exceeds maximum allowed size of " + this.remoteMaxMessageSize);
+        }
+
         executor.execute(() -> {
             if (notClosedOrFailed(operation)) {
                 try {
@@ -241,7 +248,9 @@ public final class ClientSender extends ClientSenderLinkType<Sender> implements 
 
     @Override
     protected void linkSpecificRemoteOpenHandler() {
-        // Nothing needed for sender handling
+        if (this.protonLink().getRemoteMaxMessageSize() != null) {
+            this.remoteMaxMessageSize = this.protonLink().getRemoteMaxMessageSize().longValue();
+        }
     }
 
     @Override

--- a/src/test/java/com/rabbitmq/client/amqp/impl/AmqpTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/AmqpTest.java
@@ -1522,4 +1522,53 @@ public class AmqpTest {
       connection.management().queueDelete(this.name);
     }
   }
+
+  @Test
+  void publisherShouldThrowOnMessageSizeExceedsMaximum() {
+    connection.management().queue(name).exclusive(true).declare();
+    try {
+      Publisher publisher = connection.publisherBuilder().queue(name).build();
+
+      // First small message should succeed
+      Sync firstConfirmSync = sync();
+      byte[] smallMessage = "small".getBytes(UTF_8);
+      publisher.publish(
+          publisher.message(smallMessage),
+          ctx -> {
+            if (ctx.status() == Publisher.Status.ACCEPTED) {
+              firstConfirmSync.down();
+            }
+          });
+      assertThat(firstConfirmSync).completes();
+
+      // Large message should trigger exception (16777216 is the default max, so use slightly
+      // bigger)
+      int maxMessageSize = 16777216;
+      byte[] largeMessage = new byte[maxMessageSize + 1000];
+      java.util.Arrays.fill(largeMessage, (byte) 'A');
+
+      assertThatThrownBy(() -> publisher.publish(publisher.message(largeMessage), ctx -> {}))
+          .isInstanceOf(AmqpException.AmqpInvalidMessageException.class)
+          .hasMessageContaining("Message size exceeds maximum allowed size");
+
+      // Second small message should succeed (publisher should still be valid)
+      Sync secondConfirmSync = sync();
+      byte[] anotherSmallMessage = "small2".getBytes(UTF_8);
+      publisher.publish(
+          publisher.message(anotherSmallMessage),
+          ctx -> {
+            if (ctx.status() == Publisher.Status.ACCEPTED) {
+              secondConfirmSync.down();
+            }
+          });
+      assertThat(secondConfirmSync).completes();
+
+      // Verify queue has exactly 2 messages using the CLI
+      assertThat(connection.management().queueInfo(name)).hasMessageCount(2);
+
+      publisher.close();
+    } finally {
+      connection.management().queueDelete(name);
+    }
+  }
 }

--- a/src/test/java/com/rabbitmq/client/amqp/impl/ExceptionUtilsTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/ExceptionUtilsTest.java
@@ -33,6 +33,7 @@ import org.apache.qpid.protonj2.client.exceptions.ClientConnectionRemotelyClosed
 import org.apache.qpid.protonj2.client.exceptions.ClientException;
 import org.apache.qpid.protonj2.client.exceptions.ClientIllegalStateException;
 import org.apache.qpid.protonj2.client.exceptions.ClientLinkRemotelyClosedException;
+import org.apache.qpid.protonj2.client.exceptions.ClientMessageFormatViolationException;
 import org.apache.qpid.protonj2.client.exceptions.ClientSessionRemotelyClosedException;
 import org.junit.jupiter.api.Test;
 
@@ -82,6 +83,10 @@ public class ExceptionUtilsTest {
                         "", errorCondition(ERROR_RESOURCE_DELETED)))))
         .isInstanceOf(AmqpException.AmqpEntityDoesNotExistException.class)
         .hasCauseInstanceOf(ClientLinkRemotelyClosedException.class);
+
+    assertThat(convert(new ClientMessageFormatViolationException("Message size exceeds limit")))
+        .isInstanceOf(AmqpException.AmqpInvalidMessageException.class)
+        .hasCauseInstanceOf(ClientMessageFormatViolationException.class);
   }
 
   @Test


### PR DESCRIPTION
Check message size against remote max-message-size before sending to prevent broker connection closure. When a message exceeds the limit, throw ClientMessageFormatViolationException which is converted to AmqpInvalidMessageException, keeping the connection and sender operational for subsequent messages.

Fixes #390