### PR TITLE
Retry recovery of locked exclusive queue

### DIFF
--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConnection.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConnection.java
@@ -33,6 +33,7 @@ import static java.time.Duration.ofNanos;
 
 import com.rabbitmq.client.amqp.Address;
 import com.rabbitmq.client.amqp.AmqpException;
+import com.rabbitmq.client.amqp.BackOffDelayPolicy;
 import com.rabbitmq.client.amqp.Connection;
 import com.rabbitmq.client.amqp.ConnectionSettings;
 import com.rabbitmq.client.amqp.Consumer;
@@ -135,6 +136,7 @@ final class AmqpConnection extends ResourceBase implements Connection {
   private volatile Executor dispatchingExecutor;
   private final boolean privateDispatchingExecutor;
   private final CredentialsManager.Registration credentialsRegistration;
+  private final AmqpConnectionBuilder.AmqpRecoveryConfiguration recoveryConfiguration;
 
   AmqpConnection(AmqpConnectionBuilder builder) {
     super(builder.listeners());
@@ -148,8 +150,7 @@ final class AmqpConnection extends ResourceBase implements Connection {
             ? () -> new SessionHandler.SingleSessionSessionHandler(this)
             : () -> new SessionHandler.ConnectionNativeSessionSessionHandler(this);
     BiConsumer<org.apache.qpid.protonj2.client.Connection, DisconnectionEvent> disconnectHandler;
-    AmqpConnectionBuilder.AmqpRecoveryConfiguration recoveryConfiguration =
-        builder.recoveryConfiguration();
+    this.recoveryConfiguration = builder.recoveryConfiguration();
 
     Pair<TopologyListener, EntityRecovery> topologyInfra = createTopologyInfrastructure(builder);
     this.topologyListener = topologyInfra.v1();
@@ -167,8 +168,8 @@ final class AmqpConnection extends ResourceBase implements Connection {
       this.dispatchingExecutor = de;
     }
 
-    if (recoveryConfiguration.activated()) {
-      disconnectHandler = recoveryDisconnectHandler(recoveryConfiguration, this.name());
+    if (this.recoveryConfiguration.activated()) {
+      disconnectHandler = recoveryDisconnectHandler(this.recoveryConfiguration, this.name());
     } else {
       disconnectHandler =
           (c, e) -> {
@@ -843,6 +844,10 @@ final class AmqpConnection extends ResourceBase implements Connection {
 
   MetricsCollector metricsCollector() {
     return this.environment.metricsCollector();
+  }
+
+  BackOffDelayPolicy recoveryBackOffDelayPolicy() {
+    return this.recoveryConfiguration.backOffDelayPolicy();
   }
 
   ObservationCollector observationCollector() {

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpUtils.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpUtils.java
@@ -20,6 +20,7 @@ package com.rabbitmq.client.amqp.impl;
 import com.rabbitmq.client.amqp.AmqpException;
 import com.rabbitmq.client.amqp.Publisher;
 import com.rabbitmq.client.amqp.metrics.MetricsCollector;
+import java.util.function.Predicate;
 import org.apache.qpid.protonj2.client.DeliveryState;
 import org.apache.qpid.protonj2.client.Rejected;
 import org.slf4j.Logger;
@@ -27,14 +28,18 @@ import org.slf4j.LoggerFactory;
 
 final class AmqpUtils {
 
-  static final String INFO_FIELD_QUEUE = "queue";
-  static final String INFO_FIELD_REASON = "reason";
-  static final String INFO_FIELD_REASON_MAX_LENGTH = "maxlen";
-  static final String INFO_FIELD_REASON_UNAVAILABLE = "unavailable";
-
   private static final Logger LOGGER = LoggerFactory.getLogger(AmqpUtils.class);
 
   private AmqpUtils() {}
+
+  static final Predicate<Exception> EXCLUSIVE_ACCESS_EXCEPTION_PREDICATE =
+      e ->
+          e instanceof AmqpException
+              && e.getMessage() != null
+              && e.getMessage().contains("cannot obtain exclusive access to locked queue")
+              && e.getMessage()
+                  .contains(
+                      "the exclusive property value does not match that of the original declaration");
 
   static Publisher.Status mapDeliveryState(DeliveryState in) {
     if (in.isAccepted()) {

--- a/src/main/java/com/rabbitmq/client/amqp/impl/EntityRecovery.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/EntityRecovery.java
@@ -20,6 +20,7 @@ package com.rabbitmq.client.amqp.impl;
 import com.rabbitmq.client.amqp.Management;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.Callable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,19 +103,33 @@ class EntityRecovery {
     }
   }
 
-  private void recoverQueue(RecordingTopologyListener.QueueSpec queue) {
+  void recoverQueue(RecordingTopologyListener.QueueSpec queue) {
     if (queue.exclusive() || queue.autoDelete()) {
       LOGGER.debug("Recovering queue {}", queue.name());
       try {
-        Management.QueueSpecification spec =
-            this.connection
-                .managementNoCheck()
-                .queue()
-                .name(queue.name())
-                .exclusive(queue.exclusive())
-                .autoDelete(queue.autoDelete());
-        queue.arguments().forEach(spec::argument);
-        spec.declare();
+        Callable<Void> queueCreation =
+            () -> {
+              Management.QueueSpecification spec =
+                  this.connection
+                      .managementNoCheck()
+                      .queue()
+                      .name(queue.name())
+                      .exclusive(queue.exclusive())
+                      .autoDelete(queue.autoDelete());
+              queue.arguments().forEach(spec::argument);
+              spec.declare();
+              return null;
+            };
+        if (queue.exclusive()) {
+          RetryUtils.callAndMaybeRetry(
+              queueCreation,
+              AmqpUtils.EXCLUSIVE_ACCESS_EXCEPTION_PREDICATE,
+              this.connection.recoveryBackOffDelayPolicy(),
+              "Declaring exclusive queue %s",
+              queue.name());
+        } else {
+          queueCreation.call();
+        }
         LOGGER.debug("Queue {} recovered", queue.name());
       } catch (Exception e) {
         LOGGER.warn("Error while recovering queue {}", queue.name(), e);

--- a/src/test/java/com/rabbitmq/client/amqp/impl/EntityRecoveryTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/EntityRecoveryTest.java
@@ -1,0 +1,186 @@
+// Copyright (c) 2024 Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+package com.rabbitmq.client.amqp.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.rabbitmq.client.amqp.AmqpException;
+import com.rabbitmq.client.amqp.BackOffDelayPolicy;
+import com.rabbitmq.client.amqp.Management;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EntityRecoveryTest {
+
+  private static final String EXCLUSIVE_ACCESS_MSG_FORMAT =
+      "Unexpected response code: 400 instead of 200, 201 (message: 'cannot obtain exclusive access to locked queue '%s' in vhost '/'. It could be originally declared on another connection or the exclusive property value does not match that of the original declaration.')";
+
+  @Mock AmqpConnection connection;
+  @Mock RecordingTopologyListener topologyListener;
+  @Mock Management management;
+  @Mock Management.QueueSpecification queueSpec;
+  @Mock Management.QueueInfo queueInfo;
+  @Mock RecordingTopologyListener.QueueSpec mockQueueSpec;
+
+  EntityRecovery entityRecovery;
+  BackOffDelayPolicy backOffDelayPolicy;
+
+  @BeforeEach
+  void setUp() {
+    backOffDelayPolicy = BackOffDelayPolicy.fixed(Duration.ofMillis(10));
+    lenient().when(connection.managementNoCheck()).thenReturn(management);
+    lenient().when(connection.recoveryBackOffDelayPolicy()).thenReturn(backOffDelayPolicy);
+    lenient().when(management.queue()).thenReturn(queueSpec);
+    lenient().when(queueSpec.name(anyString())).thenReturn(queueSpec);
+    lenient().when(queueSpec.exclusive(anyBoolean())).thenReturn(queueSpec);
+    lenient().when(queueSpec.autoDelete(anyBoolean())).thenReturn(queueSpec);
+    lenient().when(queueSpec.argument(anyString(), any())).thenReturn(queueSpec);
+    lenient().when(queueSpec.declare()).thenReturn(queueInfo);
+
+    entityRecovery = new EntityRecovery(connection, topologyListener);
+  }
+
+  @Test
+  void recoverQueueShouldSucceedOnFirstAttemptForExclusiveQueue() {
+    when(mockQueueSpec.name()).thenReturn("test-queue");
+    when(mockQueueSpec.exclusive()).thenReturn(true);
+    when(mockQueueSpec.autoDelete()).thenReturn(false);
+    when(mockQueueSpec.arguments()).thenReturn(Collections.emptyMap());
+
+    entityRecovery.recoverQueue(mockQueueSpec);
+
+    verify(connection).managementNoCheck();
+    verify(management).queue();
+    verify(queueSpec).name("test-queue");
+    verify(queueSpec).exclusive(true);
+    verify(queueSpec).autoDelete(false);
+    verify(queueSpec).declare();
+  }
+
+  @Test
+  void recoverQueueShouldSucceedOnFirstAttemptForAutoDeleteQueue() {
+    when(mockQueueSpec.name()).thenReturn("test-queue");
+    when(mockQueueSpec.exclusive()).thenReturn(false);
+    when(mockQueueSpec.autoDelete()).thenReturn(true);
+    when(mockQueueSpec.arguments()).thenReturn(Collections.emptyMap());
+
+    entityRecovery.recoverQueue(mockQueueSpec);
+
+    verify(connection).managementNoCheck();
+    verify(management).queue();
+    verify(queueSpec).name("test-queue");
+    verify(queueSpec).exclusive(false);
+    verify(queueSpec).autoDelete(true);
+    verify(queueSpec).declare();
+  }
+
+  @Test
+  void recoverQueueShouldRetryOnExclusiveAccessException() {
+    String q = "test-queue";
+    AmqpException exclusiveAccessException =
+        new AmqpException(String.format(EXCLUSIVE_ACCESS_MSG_FORMAT, q));
+
+    when(mockQueueSpec.name()).thenReturn(q);
+    when(mockQueueSpec.exclusive()).thenReturn(true);
+    when(mockQueueSpec.autoDelete()).thenReturn(false);
+    when(mockQueueSpec.arguments()).thenReturn(Collections.emptyMap());
+
+    when(queueSpec.declare()).thenThrow(exclusiveAccessException).thenReturn(queueInfo);
+
+    entityRecovery.recoverQueue(mockQueueSpec);
+
+    verify(queueSpec, times(2)).declare();
+  }
+
+  @Test
+  void recoverQueueShouldNotRetryOnExclusiveAccessExceptionForNonExclusiveQueue() {
+    String q = "test-queue";
+    AmqpException exclusiveAccessException =
+        new AmqpException(String.format(EXCLUSIVE_ACCESS_MSG_FORMAT, q));
+
+    when(mockQueueSpec.name()).thenReturn("test-queue");
+    when(mockQueueSpec.exclusive()).thenReturn(false);
+    when(mockQueueSpec.autoDelete()).thenReturn(true);
+    when(mockQueueSpec.arguments()).thenReturn(Collections.emptyMap());
+
+    when(queueSpec.declare()).thenThrow(exclusiveAccessException);
+
+    entityRecovery.recoverQueue(mockQueueSpec);
+
+    verify(queueSpec, times(1)).declare();
+  }
+
+  @Test
+  void recoverQueueShouldNotRetryOnOtherExceptions() {
+    AmqpException otherException = new AmqpException("Some other error");
+
+    when(mockQueueSpec.name()).thenReturn("test-queue");
+    when(mockQueueSpec.exclusive()).thenReturn(true);
+    when(mockQueueSpec.autoDelete()).thenReturn(false);
+    when(mockQueueSpec.arguments()).thenReturn(Collections.emptyMap());
+
+    when(queueSpec.declare()).thenThrow(otherException);
+
+    entityRecovery.recoverQueue(mockQueueSpec);
+
+    verify(queueSpec, times(1)).declare();
+  }
+
+  @Test
+  void recoverQueueShouldSkipNonExclusiveNonAutoDeleteQueues() {
+    when(mockQueueSpec.exclusive()).thenReturn(false);
+    when(mockQueueSpec.autoDelete()).thenReturn(false);
+
+    entityRecovery.recoverQueue(mockQueueSpec);
+
+    verify(connection, never()).managementNoCheck();
+    verify(management, never()).queue();
+  }
+
+  @Test
+  void recoverQueueShouldHandleArguments() {
+    HashMap<String, Object> arguments = new HashMap<>();
+    arguments.put("x-max-length", 1000);
+    arguments.put("x-message-ttl", 60000);
+
+    when(mockQueueSpec.name()).thenReturn("test-queue");
+    when(mockQueueSpec.exclusive()).thenReturn(true);
+    when(mockQueueSpec.autoDelete()).thenReturn(false);
+    when(mockQueueSpec.arguments()).thenReturn(arguments);
+
+    entityRecovery.recoverQueue(mockQueueSpec);
+
+    verify(queueSpec).argument("x-max-length", 1000);
+    verify(queueSpec).argument("x-message-ttl", 60000);
+    verify(queueSpec).declare();
+  }
+}

--- a/src/test/java/com/rabbitmq/client/amqp/impl/ManagementTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/ManagementTest.java
@@ -121,6 +121,19 @@ public class ManagementTest {
     assertThat(m2).isSameAs(m1);
   }
 
+  @Test
+  void exclusiveQueueCreationShouldFailWhenTryingToCreateWithSameName() {
+    Management.QueueInfo firstQueueInfo =
+        connection.management().queue().exclusive(true).autoDelete(true).declare();
+    final String queueName = firstQueueInfo.name();
+
+    try (Connection c = environment.connectionBuilder().build()) {
+      assertThatThrownBy(() -> c.management().queue(queueName).exclusive(true).declare())
+          .isInstanceOf(AmqpException.class)
+          .matches(e -> AmqpUtils.EXCLUSIVE_ACCESS_EXCEPTION_PREDICATE.test((Exception) e));
+    }
+  }
+
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   @BrokerVersionAtLeast(RABBITMQ_4_1_0)


### PR DESCRIPTION
The deletion of the previous queue incarnation can take some time to propagate in the broker state, so we back off for some time and retry.

Fixes #398