### PR TITLE
Fix Windows test execution by correcting cmd.exe path and quoting

### DIFF
--- a/src/test/java/com/rabbitmq/client/amqp/impl/Cli.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/Cli.java
@@ -152,8 +152,9 @@ abstract class Cli {
   private static Process executeCommandProcess(String command) {
     String[] finalCommand;
     if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+      command = command.replace("'", "\"");
       finalCommand = new String[4];
-      finalCommand[0] = "C:\\winnt\\system32\\cmd.exe";
+      finalCommand[0] = "cmd.exe";
       finalCommand[1] = "/y";
       finalCommand[2] = "/c";
       finalCommand[3] = command;


### PR DESCRIPTION
Fixes #326

### Description
This PR fixes an issue where the test suite fails to run on Windows environments due to how `rabbitmqctl` commands are executed in `Cli.java`.

**Changes made:**
1. **Corrected Command Interpreter Path:** Changed the hardcoded path from `C:\winnt\system32\cmd.exe` to simply `cmd.exe`. Modern Windows environments do not use the `winnt` directory, so relying on the system `PATH` is the standard approach.
2. **Proper Shell Escaping:** When running on Windows, `cmd.exe` does not recognize single quotes (`'`) as valid string wrappers, resulting in syntax errors. This PR automatically replaces single quotes with double quotes (`"`) when executing shell commands on Windows, ensuring the commands are parsed successfully.

### Testing
- Built and ran locally on Windows to ensure test commands execute correctly without throwing `The system cannot find the file specified` exceptions.