### PR TITLE
Add Consumer.Context.delayedRetry() for quorum queue delayed retry

### DIFF
--- a/src/main/java/com/rabbitmq/client/amqp/Consumer.java
+++ b/src/main/java/com/rabbitmq/client/amqp/Consumer.java
@@ -17,6 +17,8 @@
 // info@rabbitmq.com.
 package com.rabbitmq.client.amqp;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Map;
 
 /**
@@ -134,6 +136,118 @@ public interface Consumer extends AutoCloseable, Resource {
      *     in RabbitMQ</a>
      */
     void requeue(Map<String, Object> annotations);
+
+    /**
+     * Requeue the message with annotations to combine with the existing message annotations.
+     *
+     * <p>This means the message has not been processed and the broker can requeue it and deliver it
+     * to the same or a different consumer.
+     *
+     * <p>Application-specific annotation keys must start with the <code>x-opt-</code> prefix.
+     * Annotation keys the broker understands start with <code>x-</code>, but not with <code>x-opt-
+     * </code>.
+     *
+     * <p>This maps to the AMQP 1.0 <code>
+     * modified{delivery-failed = deliveryFailed, undeliverable-here = false}</code> outcome.
+     *
+     * <p><b>Only quorum queues support the modification of message annotations with the <code>
+     * modified</code> outcome.</b>
+     *
+     * @param annotations message annotations to combine with existing ones
+     * @param deliveryFailed if true, the delivery count of the message is incremented
+     * @see <a
+     *     href="https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-modified">AMQP
+     *     1.0 <code>modified</code> outcome</a>
+     * @see <a href="https://www.rabbitmq.com/docs/amqp#modified-outcome">Modified Outcome Support
+     *     in RabbitMQ</a>
+     */
+    void requeue(Map<String, Object> annotations, boolean deliveryFailed);
+
+    /**
+     * Requeue the message for redelivery after the specified delay.
+     *
+     * <p>This maps to the AMQP 1.0 <code>
+     * modified{delivery-failed = false, undeliverable-here = false}</code> outcome with the <code>
+     * x-opt-delivery-time</code> annotation set to <code>now + delay</code>.
+     *
+     * <p><b>Only quorum queues support the modification of message annotations with the <code>
+     * modified</code> outcome.</b>
+     *
+     * @param delay delivery delay from now
+     * @see <a
+     *     href="https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-modified">AMQP
+     *     1.0 <code>modified</code> outcome</a>
+     * @see <a href="https://www.rabbitmq.com/docs/amqp#modified-outcome">Modified Outcome Support
+     *     in RabbitMQ</a>
+     * @see <a href="https://www.rabbitmq.com/docs/quorum-queues#delayed-retry">Delayed Retry in
+     *     RabbitMQ</a>
+     */
+    void delayedRetry(Duration delay);
+
+    /**
+     * Requeue the message for redelivery after the specified delay.
+     *
+     * <p>This maps to the AMQP 1.0 <code>
+     * modified{delivery-failed = false, undeliverable-here = false}</code> outcome with the <code>
+     * x-opt-delivery-time</code> annotation set to <code>now + delay</code>.
+     *
+     * <p><b>Only quorum queues support the modification of message annotations with the <code>
+     * modified</code> outcome.</b>
+     *
+     * @param delay delivery delay from now
+     * @param deliveryFailed if true, the delivery count of the message is incremented
+     * @see <a
+     *     href="https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-modified">AMQP
+     *     1.0 <code>modified</code> outcome</a>
+     * @see <a href="https://www.rabbitmq.com/docs/amqp#modified-outcome">Modified Outcome Support
+     *     in RabbitMQ</a>
+     * @see <a href="https://www.rabbitmq.com/docs/quorum-queues#delayed-retry">Delayed Retry in
+     *     RabbitMQ</a>
+     */
+    void delayedRetry(Duration delay, boolean deliveryFailed);
+
+    /**
+     * Requeue the message for redelivery at the specified time.
+     *
+     * <p>This maps to the AMQP 1.0 <code>
+     * modified{delivery-failed = false, undeliverable-here = false}</code> outcome with the <code>
+     * x-opt-delivery-time</code> annotation set to the specified time.
+     *
+     * <p><b>Only quorum queues support the modification of message annotations with the <code>
+     * modified</code> outcome.</b>
+     *
+     * @param deliveryTime absolute delivery time
+     * @see <a
+     *     href="https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-modified">AMQP
+     *     1.0 <code>modified</code> outcome</a>
+     * @see <a href="https://www.rabbitmq.com/docs/amqp#modified-outcome">Modified Outcome Support
+     *     in RabbitMQ</a>
+     * @see <a href="https://www.rabbitmq.com/docs/quorum-queues#delayed-retry">Delayed Retry in
+     *     RabbitMQ</a>
+     */
+    void delayedRetry(Instant deliveryTime);
+
+    /**
+     * Requeue the message for redelivery at the specified time.
+     *
+     * <p>This maps to the AMQP 1.0 <code>
+     * modified{delivery-failed = false, undeliverable-here = false}</code> outcome with the <code>
+     * x-opt-delivery-time</code> annotation set to the specified time.
+     *
+     * <p><b>Only quorum queues support the modification of message annotations with the <code>
+     * modified</code> outcome.</b>
+     *
+     * @param deliveryTime absolute delivery time
+     * @param deliveryFailed if true, the delivery count of the message is incremented
+     * @see <a
+     *     href="https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-modified">AMQP
+     *     1.0 <code>modified</code> outcome</a>
+     * @see <a href="https://www.rabbitmq.com/docs/amqp#modified-outcome">Modified Outcome Support
+     *     in RabbitMQ</a>
+     * @see <a href="https://www.rabbitmq.com/docs/quorum-queues#delayed-retry">Delayed Retry in
+     *     RabbitMQ</a>
+     */
+    void delayedRetry(Instant deliveryTime, boolean deliveryFailed);
 
     /**
      * Create a batch context to accumulate message contexts and settle them at once.

--- a/src/main/java/com/rabbitmq/client/amqp/Consumer.java
+++ b/src/main/java/com/rabbitmq/client/amqp/Consumer.java
@@ -85,9 +85,10 @@ public interface Consumer extends AutoCloseable, Resource {
      * <p>This means the message cannot be processed because it is invalid, the broker can drop it
      * or dead-letter it if it is configured.
      *
-     * <p>Application-specific annotation keys must start with the <code>x-opt-</code> prefix.
-     * Annotation keys the broker understands start with <code>x-</code>, but not with <code>x-opt-
-     * </code>.
+     * <p>Custom application-specific annotation keys should start with the <code>x-opt-</code>
+     * prefix so they are safely ignored if not understood. Keys starting with <code>x-</code> (but
+     * not <code>x-opt-</code>) are reserved for broker-specific features, and unrecognized keys
+     * will cause a protocol error.
      *
      * <p>This maps to the AMQP 1.0 <code>
      * modified{delivery-failed = true, undeliverable-here = true}</code> outcome.
@@ -118,9 +119,10 @@ public interface Consumer extends AutoCloseable, Resource {
      * <p>This means the message has not been processed and the broker can requeue it and deliver it
      * to the same or a different consumer.
      *
-     * <p>Application-specific annotation keys must start with the <code>x-opt-</code> prefix.
-     * Annotation keys the broker understands start with <code>x-</code>, but not with <code>x-opt-
-     * </code>.
+     * <p>Custom application-specific annotation keys should start with the <code>x-opt-</code>
+     * prefix so they are safely ignored if not understood. Keys starting with <code>x-</code> (but
+     * not <code>x-opt-</code>) are reserved for broker-specific features, and unrecognized keys
+     * will cause a protocol error.
      *
      * <p>This maps to the AMQP 1.0 <code>
      * modified{delivery-failed = false, undeliverable-here = false}</code> outcome.
@@ -143,9 +145,10 @@ public interface Consumer extends AutoCloseable, Resource {
      * <p>This means the message has not been processed and the broker can requeue it and deliver it
      * to the same or a different consumer.
      *
-     * <p>Application-specific annotation keys must start with the <code>x-opt-</code> prefix.
-     * Annotation keys the broker understands start with <code>x-</code>, but not with <code>x-opt-
-     * </code>.
+     * <p>Custom application-specific annotation keys should start with the <code>x-opt-</code>
+     * prefix so they are safely ignored if not understood. Keys starting with <code>x-</code> (but
+     * not <code>x-opt-</code>) are reserved for broker-specific features, and unrecognized keys
+     * will cause a protocol error.
      *
      * <p>This maps to the AMQP 1.0 <code>
      * modified{delivery-failed = deliveryFailed, undeliverable-here = false}</code> outcome.

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConsumer.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConsumer.java
@@ -21,6 +21,7 @@ import static com.rabbitmq.client.amqp.Resource.State.CLOSED;
 import static com.rabbitmq.client.amqp.Resource.State.CLOSING;
 import static com.rabbitmq.client.amqp.Resource.State.OPEN;
 import static com.rabbitmq.client.amqp.impl.AmqpConsumerBuilder.NO_OP_SUBSCRIPTION_LISTENER;
+import static com.rabbitmq.client.amqp.impl.Assert.notNull;
 import static com.rabbitmq.client.amqp.metrics.MetricsCollector.ConsumeDisposition.ACCEPTED;
 import static com.rabbitmq.client.amqp.metrics.MetricsCollector.ConsumeDisposition.DISCARDED;
 import static com.rabbitmq.client.amqp.metrics.MetricsCollector.ConsumeDisposition.REQUEUED;
@@ -35,8 +36,11 @@ import com.rabbitmq.client.amqp.ConsumerBuilder.StreamOptions;
 import com.rabbitmq.client.amqp.ConsumerBuilder.SubscriptionListener;
 import com.rabbitmq.client.amqp.metrics.MetricsCollector;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -640,10 +644,41 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
 
     @Override
     public void requeue(Map<String, Object> annotations) {
+      this.requeue(annotations, false);
+    }
+
+    @Override
+    public void requeue(Map<String, Object> annotations, boolean deliveryFailed) {
       annotations = annotations == null ? Collections.emptyMap() : annotations;
       Utils.checkMessageAnnotations(annotations);
       this.settle(
-          DeliveryState.modified(false, false, annotations), REQUEUED, "requeue (modified)");
+          DeliveryState.modified(deliveryFailed, false, annotations),
+          REQUEUED,
+          "requeue (modified)");
+    }
+
+    @Override
+    public void delayedRetry(Duration delay) {
+      this.delayedRetry(delay, false);
+    }
+
+    @Override
+    public void delayedRetry(Duration delay, boolean deliveryFailed) {
+      notNull(delay, "Delay");
+      this.delayedRetry(Instant.now().plus(delay), deliveryFailed);
+    }
+
+    @Override
+    public void delayedRetry(Instant deliveryTime) {
+      this.delayedRetry(deliveryTime, false);
+    }
+
+    @Override
+    public void delayedRetry(Instant deliveryTime, boolean deliveryFailed) {
+      notNull(deliveryTime, "Delivery time");
+      Map<String, Object> annotations =
+          Collections.singletonMap(AmqpUtils.ANN_DELIVERY_TIME, Date.from(deliveryTime));
+      this.requeue(annotations, deliveryFailed);
     }
 
     @Override
@@ -770,6 +805,39 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
     }
 
     @Override
+    public void requeue(Map<String, Object> annotations, boolean deliveryFailed) {
+      annotations = annotations == null ? Collections.emptyMap() : annotations;
+      Utils.checkMessageAnnotations(annotations);
+      Modified state =
+          new Modified(
+              deliveryFailed, false, ClientConversionSupport.toSymbolKeyedMap(annotations));
+      this.settle(state, REQUEUED, "requeue (modified)");
+    }
+
+    @Override
+    public void delayedRetry(Duration delay) {
+      this.delayedRetry(delay, false);
+    }
+
+    @Override
+    public void delayedRetry(Duration delay, boolean deliveryFailed) {
+      this.delayedRetry(Instant.now().plus(delay), deliveryFailed);
+    }
+
+    @Override
+    public void delayedRetry(Instant deliveryTime) {
+      this.delayedRetry(deliveryTime, false);
+    }
+
+    @Override
+    public void delayedRetry(Instant deliveryTime, boolean deliveryFailed) {
+      notNull(deliveryTime, "Delivery time");
+      Map<String, Object> annotations =
+          Collections.singletonMap(AmqpUtils.ANN_DELIVERY_TIME, Date.from(deliveryTime));
+      this.requeue(annotations, deliveryFailed);
+    }
+
+    @Override
     public BatchContext batch(int batchSizeHint) {
       return this;
     }
@@ -834,6 +902,31 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
 
     @Override
     public void requeue(Map<String, Object> annotations) {
+      throw new UnsupportedOperationException("auto-settle on, message is already disposed");
+    }
+
+    @Override
+    public void requeue(Map<String, Object> annotations, boolean deliveryFailed) {
+      throw new UnsupportedOperationException("auto-settle on, message is already disposed");
+    }
+
+    @Override
+    public void delayedRetry(Duration delay) {
+      throw new UnsupportedOperationException("auto-settle on, message is already disposed");
+    }
+
+    @Override
+    public void delayedRetry(Duration delay, boolean deliveryFailed) {
+      throw new UnsupportedOperationException("auto-settle on, message is already disposed");
+    }
+
+    @Override
+    public void delayedRetry(Instant deliveryTime, boolean deliveryFailed) {
+      throw new UnsupportedOperationException("auto-settle on, message is already disposed");
+    }
+
+    @Override
+    public void delayedRetry(Instant deliveryTime) {
       throw new UnsupportedOperationException("auto-settle on, message is already disposed");
     }
 

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpUtils.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpUtils.java
@@ -32,6 +32,8 @@ final class AmqpUtils {
 
   private AmqpUtils() {}
 
+  static final String ANN_DELIVERY_TIME = "x-opt-delivery-time";
+
   static final Predicate<Exception> EXCLUSIVE_ACCESS_EXCEPTION_PREDICATE =
       e ->
           e instanceof AmqpException

--- a/src/test/java/com/rabbitmq/client/amqp/impl/BatchDispositionTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/BatchDispositionTest.java
@@ -23,6 +23,8 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.rabbitmq.client.amqp.Consumer;
 import com.rabbitmq.client.amqp.Message;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -150,6 +152,31 @@ public class BatchDispositionTest {
       dispose();
     }
 
+    @Override
+    public void requeue(Map<String, Object> annotations, boolean deliveryFailed) {
+      dispose();
+    }
+
+    @Override
+    public void delayedRetry(Duration delay) {
+      dispose();
+    }
+
+    @Override
+    public void delayedRetry(Duration delay, boolean deliveryFailed) {
+      dispose();
+    }
+
+    @Override
+    public void delayedRetry(Instant deliveryTime, boolean deliveryFailed) {
+      dispose();
+    }
+
+    @Override
+    public void delayedRetry(Instant deliveryTime) {
+      dispose();
+    }
+
     private void dispose() {
       dispositionFrameCount.inc();
       dispositionRangeSize.update(1);
@@ -203,6 +230,31 @@ public class BatchDispositionTest {
 
     @Override
     public void requeue(Map<String, Object> annotations) {
+      dispose();
+    }
+
+    @Override
+    public void requeue(Map<String, Object> annotations, boolean deliveryFailed) {
+      dispose();
+    }
+
+    @Override
+    public void delayedRetry(Duration delay) {
+      dispose();
+    }
+
+    @Override
+    public void delayedRetry(Duration delay, boolean deliveryFailed) {
+      dispose();
+    }
+
+    @Override
+    public void delayedRetry(Instant deliveryTime) {
+      dispose();
+    }
+
+    @Override
+    public void delayedRetry(Instant deliveryTime, boolean deliveryFailed) {
       dispose();
     }
 

--- a/src/test/java/com/rabbitmq/client/amqp/impl/DelayedRetryTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/DelayedRetryTest.java
@@ -24,10 +24,12 @@ import static java.time.Duration.ofMillis;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.rabbitmq.client.amqp.Connection;
+import com.rabbitmq.client.amqp.Consumer;
 import com.rabbitmq.client.amqp.Management;
 import com.rabbitmq.client.amqp.Message;
 import com.rabbitmq.client.amqp.Publisher;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -37,6 +39,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @AmqpTestInfrastructure
 public class DelayedRetryTest {
@@ -108,8 +113,10 @@ public class DelayedRetryTest {
         .isCloseTo(retryDelay, retryDelay.dividedBy(5));
   }
 
-  @Test
-  void explicitDeliveryTimeInMessageShouldOverrideRetryDelay() {
+  @ParameterizedTest
+  @EnumSource(ExplicitDeliveryTimeStrategy.class)
+  void explicitDeliveryTimeInMessageShouldOverrideRetryDelay(
+      ExplicitDeliveryTimeStrategy strategy) {
     Duration retryDelay = ofMillis(100);
     Duration deliveryTimeOffset = ofMillis(1000);
     this.management
@@ -122,9 +129,8 @@ public class DelayedRetryTest {
         .declare();
 
     Publisher publisher = this.connection.publisherBuilder().queue(q).build();
-    AtomicInteger deliveryCount = new AtomicInteger();
+    AtomicInteger count = new AtomicInteger();
     TestUtils.Sync redeliveredSync = TestUtils.sync();
-    Queue<Message> messages = new ArrayBlockingQueue<>(2);
     AtomicLong timeBetweenDeliveriesNs = new AtomicLong();
 
     this.connection
@@ -132,15 +138,94 @@ public class DelayedRetryTest {
         .queue(q)
         .messageHandler(
             (context, message) -> {
-              deliveryCount.incrementAndGet();
-              messages.offer(message);
-              if (deliveryCount.get() == 1) {
+              if (count.incrementAndGet() == 1) {
                 timeBetweenDeliveriesNs.set(System.nanoTime());
-                long time = System.currentTimeMillis() + deliveryTimeOffset.toMillis();
-                context.requeue(Map.of("x-opt-delivery-time", time));
+                strategy.apply(context, deliveryTimeOffset);
               } else {
-                long now = System.nanoTime();
-                timeBetweenDeliveriesNs.set(now - timeBetweenDeliveriesNs.get());
+                timeBetweenDeliveriesNs.set(System.nanoTime() - timeBetweenDeliveriesNs.get());
+                context.accept();
+                redeliveredSync.down();
+              }
+            })
+        .build();
+
+    publisher.publish(publisher.message(), ctx -> {});
+    assertThat(redeliveredSync).completes();
+    waitAtMost(() -> management.queueInfo(q).messageCount() == 0);
+
+    assertThat(Duration.ofNanos(timeBetweenDeliveriesNs.get()))
+        .isCloseTo(deliveryTimeOffset, deliveryTimeOffset.dividedBy(5));
+  }
+
+  @ParameterizedTest
+  @EnumSource(DelayedRetryStrategy.class)
+  void delayedRetryShouldRedeliver(DelayedRetryStrategy strategy) {
+    Duration retryDelay = ofMillis(1000);
+    this.management
+        .queue()
+        .name(q)
+        .quorum()
+        .delayedRetryType(ALL)
+        .delayedRetryMin(retryDelay)
+        .queue()
+        .declare();
+
+    Publisher publisher = this.connection.publisherBuilder().queue(q).build();
+    AtomicInteger count = new AtomicInteger();
+    TestUtils.Sync redeliveredSync = TestUtils.sync();
+    AtomicLong timeBetweenDeliveriesNs = new AtomicLong();
+
+    this.connection
+        .consumerBuilder()
+        .queue(q)
+        .messageHandler(
+            (context, message) -> {
+              if (count.incrementAndGet() == 1) {
+                timeBetweenDeliveriesNs.set(System.nanoTime());
+                strategy.apply(context, retryDelay);
+              } else {
+                timeBetweenDeliveriesNs.set(System.nanoTime() - timeBetweenDeliveriesNs.get());
+                context.accept();
+                redeliveredSync.down();
+              }
+            })
+        .build();
+
+    publisher.publish(publisher.message(), ctx -> {});
+    assertThat(redeliveredSync).completes();
+    waitAtMost(() -> management.queueInfo(q).messageCount() == 0);
+
+    assertThat(Duration.ofNanos(timeBetweenDeliveriesNs.get()))
+        .isCloseTo(retryDelay, retryDelay.dividedBy(5));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void deliveryFailedFlagShouldControlDeliveryCount(boolean deliveryFailed) {
+    Duration retryDelay = ofMillis(500);
+    this.management
+        .queue()
+        .name(q)
+        .quorum()
+        .delayedRetryType(ALL)
+        .delayedRetryMin(retryDelay)
+        .queue()
+        .declare();
+
+    Publisher publisher = this.connection.publisherBuilder().queue(q).build();
+    AtomicInteger count = new AtomicInteger();
+    TestUtils.Sync redeliveredSync = TestUtils.sync();
+    Queue<Message> messages = new ArrayBlockingQueue<>(1);
+
+    this.connection
+        .consumerBuilder()
+        .queue(q)
+        .messageHandler(
+            (context, message) -> {
+              if (count.incrementAndGet() == 1) {
+                context.delayedRetry(retryDelay, deliveryFailed);
+              } else {
+                messages.offer(message);
                 context.accept();
                 redeliveredSync.down();
               }
@@ -150,14 +235,73 @@ public class DelayedRetryTest {
     publisher.publish(publisher.message(), ctx -> {});
     assertThat(redeliveredSync).completes();
 
-    Message message1 = messages.poll();
-    Message message2 = messages.poll();
-
-    assertThat(message1).isNotNull();
-    assertThat(message2).isNotNull();
-
+    Message redelivered = messages.poll();
+    assertThat(redelivered).isNotNull().hasDeliveryCount(deliveryFailed ? 1L : 0L);
     waitAtMost(() -> management.queueInfo(q).messageCount() == 0);
-    assertThat(Duration.ofNanos(timeBetweenDeliveriesNs.get()))
-        .isCloseTo(deliveryTimeOffset, deliveryTimeOffset.dividedBy(5));
+  }
+
+  enum ExplicitDeliveryTimeStrategy {
+    REQUEUE_WITH_ANNOTATION {
+      @Override
+      public void apply(Consumer.Context ctx, Duration deliveryTimeOffset) {
+        long time = System.currentTimeMillis() + deliveryTimeOffset.toMillis();
+        ctx.requeue(Map.of("x-opt-delivery-time", time));
+      }
+    },
+    DELAYED_RETRY_DURATION {
+      @Override
+      public void apply(Consumer.Context ctx, Duration deliveryTimeOffset) {
+        ctx.delayedRetry(deliveryTimeOffset);
+      }
+    },
+    DELAYED_RETRY_INSTANT {
+      @Override
+      public void apply(Consumer.Context ctx, Duration deliveryTimeOffset) {
+        ctx.delayedRetry(Instant.now().plus(deliveryTimeOffset));
+      }
+    };
+
+    public abstract void apply(Consumer.Context ctx, Duration deliveryTimeOffset);
+  }
+
+  enum DelayedRetryStrategy {
+    DURATION {
+      @Override
+      public void apply(Consumer.Context ctx, Duration delay) {
+        ctx.delayedRetry(delay);
+      }
+    },
+    DURATION_NO_FAILURE {
+      @Override
+      public void apply(Consumer.Context ctx, Duration delay) {
+        ctx.delayedRetry(delay, false);
+      }
+    },
+    DURATION_DELIVERY_FAILED {
+      @Override
+      public void apply(Consumer.Context ctx, Duration delay) {
+        ctx.delayedRetry(delay, true);
+      }
+    },
+    INSTANT {
+      @Override
+      public void apply(Consumer.Context ctx, Duration delay) {
+        ctx.delayedRetry(Instant.now().plus(delay));
+      }
+    },
+    INSTANT_NO_FAILURE {
+      @Override
+      public void apply(Consumer.Context ctx, Duration delay) {
+        ctx.delayedRetry(Instant.now().plus(delay), false);
+      }
+    },
+    INSTANT_DELIVERY_FAILED {
+      @Override
+      public void apply(Consumer.Context ctx, Duration delay) {
+        ctx.delayedRetry(Instant.now().plus(delay), true);
+      }
+    };
+
+    public abstract void apply(Consumer.Context ctx, Duration delay);
   }
 }


### PR DESCRIPTION
Convenience methods delayedRetry(Duration) and delayedRetry(Instant), each with an optional deliveryFailed overload, set the x-opt-delivery-time annotation and requeue the message via the AMQP modified outcome, scheduling redelivery at a precise future time without requiring callers to build the annotation map manually.

requeue(Map, boolean) is also added to expose the delivery-failed flag on the annotated requeue path. When deliveryFailed is true the broker increments the message's delivery count, which interacts with the queue's DelayedRetryType configuration (FAILED vs RETURNED vs ALL).

Fixes #427