### PR TITLE
fix(network): disable hostname verification in dev mode

### DIFF
--- a/src/main/java/com/rabbitmq/client/amqp/impl/DefaultConnectionSettings.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/DefaultConnectionSettings.java
@@ -434,6 +434,7 @@ abstract class DefaultConnectionSettings<T> implements ConnectionSettings<T> {
         throw new AmqpException(e);
       }
       this.sslContext = context;
+      this.hostnameVerification(false);
       return this;
     }
 


### PR DESCRIPTION
The TLS dev mode already trust all servers, so this is mostly for consistency.