### PR TITLE
Miscellaneous consumer lifecycle fixes

### DIFF
--- a/src/main/java/com/rabbitmq/client/amqp/Consumer.java
+++ b/src/main/java/com/rabbitmq/client/amqp/Consumer.java
@@ -31,7 +31,14 @@ import java.util.Map;
  */
 public interface Consumer extends AutoCloseable, Resource {
 
-  /** Pause the consumer to stop receiving messages. */
+  /**
+   * Pause the consumer to stop receiving messages.
+   *
+   * <p>Messages already in flight when this method is called may still be delivered after it
+   * returns.
+   *
+   * @throws AmqpException if the consumer is not open
+   */
   void pause();
 
   /**
@@ -41,7 +48,11 @@ public interface Consumer extends AutoCloseable, Resource {
    */
   long unsettledMessageCount();
 
-  /** Request to receive messages again. */
+  /**
+   * Request to receive messages again.
+   *
+   * @throws AmqpException if the consumer is not open
+   */
   void unpause();
 
   /** Close the consumer with its resources. */

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConnection.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConnection.java
@@ -485,7 +485,6 @@ final class AmqpConnection extends ResourceBase
         try {
           LOGGER.debug("Recovering consumer {} (queue '{}')", consumer.id(), consumer.queue());
           consumer.recoverAfterConnectionFailure();
-          consumer.state(OPEN);
           LOGGER.debug("Recovered consumer {} (queue '{}')", consumer.id(), consumer.queue());
         } catch (AmqpException.AmqpConnectionException ex) {
           LOGGER.warn(

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConsumer.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConsumer.java
@@ -192,6 +192,7 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
 
   @Override
   public void pause() {
+    checkOpen();
     if (this.pauseStatus.compareAndSet(PauseStatus.UNPAUSED, PauseStatus.PAUSING)) {
       try {
         CountDownLatch latch = new CountDownLatch(1);

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConsumer.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConsumer.java
@@ -196,22 +196,25 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
       try {
         CountDownLatch latch = new CountDownLatch(1);
         this.echoedFlowAfterPauseLatch.set(latch);
-        this.link.executor.execute(this::doPause);
+        Link linkAtPause = this.link;
+        onExecutor(linkAtPause, () -> doPause(linkAtPause));
         try {
           boolean echoed =
               latch.await(this.pauseHandshakeTimeout.toMillis(), TimeUnit.MILLISECONDS);
           if (!echoed) {
-            // doPause may already have zeroed the link credit, so resetting to UNPAUSED here
+            // doPause may already have zeroed the link credit, so falling back to UNPAUSED here
             // would leave the consumer stalled with no way to re-credit the link
             LOGGER.warn("Did not receive echoed flow to pause receiver");
           }
-          this.pauseStatus.set(PauseStatus.PAUSED);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
         }
       } catch (Exception e) {
         LOGGER.warn("Exception while pausing consumer: {}", e.getMessage(), e);
-        this.pauseStatus.set(PauseStatus.PAUSED);
+      } finally {
+        // CAS, not set: a concurrent recovery may legitimately have moved the status, and its
+        // write must win. The finally guarantees the status never stays at PAUSING (L3)
+        this.pauseStatus.compareAndSet(PauseStatus.PAUSING, PauseStatus.PAUSED);
       }
     }
   }
@@ -653,8 +656,7 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
     }
   }
 
-  private void doPause() {
-    Link link = this.link;
+  private void doPause(Link link) {
     link.creditState.updateCredit(0);
     link.creditState.updateEcho(true);
     link.sessionWindow.writeFlow(link.protonReceiver);
@@ -662,6 +664,10 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
 
   boolean pausedOrPausing() {
     return this.pauseStatus.get() != PauseStatus.UNPAUSED;
+  }
+
+  PauseStatus pauseStatus() {
+    return this.pauseStatus.get();
   }
 
   enum PauseStatus {

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConsumer.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConsumer.java
@@ -553,8 +553,11 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
       // the previous generation is gone; its counters are irrelevant from here on, so there is
       // no hand-reset of unsettledMessageCount: unsettledMessageCount() already reads the new
       // Link's counter, which starts at zero
-      this.pauseStatus.set(PauseStatus.UNPAUSED);
-      newLink.receiver.addCredit(this.initialCredits);
+      if (this.pausedOrPausing()) {
+        LOGGER.debug("Consumer {} is paused, not granting credit after recovery", this.id);
+      } else {
+        newLink.receiver.addCredit(this.initialCredits);
+      }
     } catch (ClientException e) {
       throw ExceptionUtils.convert(e);
     }

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConsumer.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConsumer.java
@@ -124,6 +124,13 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
   private final ConsumerWorkService consumerWorkService;
   // package-private for testing
   Duration pauseHandshakeTimeout = Duration.ofSeconds(10);
+  // package-private for testing: runs after the native receiver has been reopened during
+  // recovery, immediately before the new generation is activated
+  volatile Runnable beforeActivateHook = () -> {};
+
+  // Arbitrates the two writers of the consumer lifecycle: close() and the tail of
+  // recoverAfterConnectionFailure. Held only across field writes, never across I/O.
+  private final Object lifecycleLock = new Object();
 
   // One instance per receiver generation. Everything the credit path touches lives here, so a
   // generation's state cannot outlive the executor that owns it.
@@ -172,8 +179,9 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
     try {
       Link openedLink = this.openLink(this.sessionHandler.session());
       this.directReplyToAddress = openedLink.receiver.address();
-      this.state(OPEN);
-      openedLink.receiver.addCredit(this.initialCredits);
+      if (this.activate(openedLink)) {
+        openedLink.receiver.addCredit(this.initialCredits);
+      }
     } catch (ClientException e) {
       AmqpException ex = ExceptionUtils.convert(e);
       this.close(ex);
@@ -428,15 +436,15 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
             this.subscriptionListener,
             createNativeHandler(this.messageHandler, holder),
             this.nativeCloseHandler);
-    return installLink(receiver, holder);
+    return buildLink(receiver, holder);
   }
 
-  // Builds the Link for an already-open native receiver and publishes it to both the
-  // generation-local holder (read by the native handler) and this.link (read by everything
-  // else), on the proton executor, before returning. Credit must not be granted until this
-  // returns : a freshly opened receiver has zero credit (creditWindow(0)), so no delivery
-  // can arrive before its generation's Link exists.
-  private Link installLink(ClientReceiver receiver, AtomicReference<Link> holder) {
+  // Builds the Link for an already-open native receiver and publishes it to the
+  // generation-local holder (read by the native handler), on the proton executor, before
+  // returning. this.link is published separately, by activate(), which arbitrates the
+  // publication against close(). The holder is still populated before any credit is granted,
+  // which is all invariant I1 needs.
+  private Link buildLink(ClientReceiver receiver, AtomicReference<Link> holder) {
     try {
       Scheduler executor = receiver.executor();
       CountDownLatch publishedLatch = new CountDownLatch(1);
@@ -464,7 +472,6 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
             protonReceiver.creditStateUpdateHandler(decorator);
 
             holder.set(newLink);
-            this.link = newLink;
             publishedLatch.countDown();
           });
       if (!publishedLatch.await(10, TimeUnit.SECONDS)) {
@@ -476,7 +483,27 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
     }
   }
 
+  // Publishes the new generation and moves the consumer to OPEN, atomically with respect to
+  // close(). Returns false if the consumer was closed concurrently: the caller then still owns
+  // the receiver it opened and must close it.
+  private boolean activate(Link newLink) {
+    synchronized (this.lifecycleLock) {
+      if (this.closed.get()) {
+        return false;
+      }
+      Link previous = this.link;
+      if (previous != null && previous != newLink) {
+        previous.current = false;
+      }
+      this.link = newLink;
+      this.state(OPEN);
+      return true;
+    }
+  }
+
   void recoverAfterConnectionFailure() {
+    // optimization that avoids a pointless retry loop for a consumer already closed;
+    // activate() is the actual guarantee
     if (this.closed.get()) {
       LOGGER.debug("Consumer {} is closed, skipping recovery", this.id);
       return;
@@ -503,29 +530,27 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
             "Create AMQP receiver to address '%s'",
             this.address);
 
-    // Check again after potentially long retry operation
+    // optimization that avoids a pointless buildLink for a consumer already closed after a
+    // potentially long retry operation; activate() is the actual guarantee
     if (this.closed.get()) {
       LOGGER.debug("Consumer {} was closed during recovery, cleaning up new receiver", this.id);
-      try {
-        newReceiver.close();
-      } catch (Exception e) {
-        LOGGER.debug("Error while closing receiver during cleanup: {}", e.getMessage());
-      }
+      closeQuietly(newReceiver);
       return;
     }
 
-    Link previousLink = this.link;
     try {
-      Link newLink = this.installLink(newReceiver, holder);
+      Link newLink = this.buildLink(newReceiver, holder);
       this.directReplyToAddress = newReceiver.address();
+      this.beforeActivateHook.run();
+      if (!this.activate(newLink)) {
+        LOGGER.debug("Consumer {} was closed during recovery, closing new receiver", this.id);
+        closeQuietly(newReceiver);
+        return;
+      }
       // the previous generation is gone; its counters are irrelevant from here on, so there is
       // no hand-reset of unsettledMessageCount: unsettledMessageCount() already reads the new
       // Link's counter, which starts at zero
-      if (previousLink != null) {
-        previousLink.current = false;
-      }
       this.pauseStatus.set(PauseStatus.UNPAUSED);
-      this.state(OPEN);
       newLink.receiver.addCredit(this.initialCredits);
     } catch (ClientException e) {
       throw ExceptionUtils.convert(e);
@@ -533,26 +558,38 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
   }
 
   void close(Throwable cause) {
-    if (this.closed.compareAndSet(false, true)) {
+    Link linkToClose;
+    synchronized (this.lifecycleLock) {
+      if (!this.closed.compareAndSet(false, true)) {
+        return;
+      }
+      linkToClose = this.link;
       this.state(CLOSING, cause);
-      if (this.consumerWorkService != null) {
-        this.consumerWorkService.unregister(this);
+    }
+    if (this.consumerWorkService != null) {
+      this.consumerWorkService.unregister(this);
+    }
+    this.connection.removeConsumer(this);
+    try {
+      if (linkToClose != null) {
+        linkToClose.receiver.close();
       }
-      this.connection.removeConsumer(this);
-      try {
-        Link currentLink = this.link;
-        if (currentLink != null) {
-          currentLink.receiver.close();
-        }
-        this.sessionHandler.close();
-      } catch (Exception e) {
-        LOGGER.warn("Error while closing receiver", e);
-      }
-      this.state(CLOSED, cause);
-      MetricsCollector mc = this.metricsCollector;
-      if (mc != null) {
-        mc.closeConsumer();
-      }
+      this.sessionHandler.close();
+    } catch (Exception e) {
+      LOGGER.warn("Error while closing receiver", e);
+    }
+    this.state(CLOSED, cause);
+    MetricsCollector mc = this.metricsCollector;
+    if (mc != null) {
+      mc.closeConsumer();
+    }
+  }
+
+  private static void closeQuietly(ClientReceiver receiver) {
+    try {
+      receiver.close();
+    } catch (Exception e) {
+      LOGGER.debug("Error while closing receiver during cleanup: {}", e.getMessage());
     }
   }
 

--- a/src/main/java/com/rabbitmq/client/amqp/impl/ResourceBase.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/ResourceBase.java
@@ -60,13 +60,23 @@ abstract class ResourceBase implements Resource {
   }
 
   protected void state(Resource.State state, Throwable failureCause) {
-    Resource.State previousState = this.state.getAndSet(state);
+    // once closing has started, only CLOSED may follow: a late OPEN from a concurrent recovery
+    // must not resurrect a closed resource
+    Resource.State previousState =
+        this.state.getAndUpdate(current -> rejected(current, state) ? current : state);
+    if (rejected(previousState, state)) {
+      return;
+    }
     if (state != previousState) {
       if ((state == CLOSING || state == CLOSED) && this.closeReason == null) {
         this.closeReason = failureCause;
       }
       this.dispatch(previousState, state, failureCause);
     }
+  }
+
+  private static boolean rejected(Resource.State current, Resource.State next) {
+    return (current == CLOSING || current == CLOSED) && next != CLOSED;
   }
 
   private void dispatch(State previous, State current, Throwable failureCause) {

--- a/src/test/java/com/rabbitmq/client/amqp/impl/AmqpConsumerTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/AmqpConsumerTest.java
@@ -20,6 +20,7 @@ package com.rabbitmq.client.amqp.impl;
 import static com.rabbitmq.client.amqp.Management.QueueType.QUORUM;
 import static com.rabbitmq.client.amqp.Management.QueueType.STREAM;
 import static com.rabbitmq.client.amqp.Resource.State.CLOSED;
+import static com.rabbitmq.client.amqp.Resource.State.CLOSING;
 import static com.rabbitmq.client.amqp.Resource.State.OPEN;
 import static com.rabbitmq.client.amqp.Resource.State.RECOVERING;
 import static com.rabbitmq.client.amqp.impl.Assertions.assertThat;
@@ -42,8 +43,12 @@ import com.rabbitmq.client.amqp.Resource;
 import com.rabbitmq.client.amqp.impl.TestUtils.Sync;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -394,6 +399,107 @@ public class AmqpConsumerTest {
     assertThat(publishSync).completes();
 
     assertThat(consumeSync).completes();
+  }
+
+  @Test
+  void consumerClosedDuringRecoveryStaysClosed(TestInfo info) throws InterruptedException {
+    String cName = name(info);
+    connection.management().queue(this.q).declare();
+    Connection c =
+        ((AmqpConnectionBuilder) environment.connectionBuilder())
+            .name(cName)
+            .recovery()
+            .backOffDelayPolicy(backOffDelayPolicy)
+            .connectionBuilder()
+            .build();
+
+    List<Resource.State[]> transitions = new CopyOnWriteArrayList<>();
+    AmqpConsumer consumer =
+        (AmqpConsumer)
+            c.consumerBuilder()
+                .queue(this.q)
+                .listeners(
+                    ctx ->
+                        transitions.add(
+                            new Resource.State[] {ctx.previousState(), ctx.currentState()}))
+                .messageHandler((ctx, msg) -> {})
+                .build();
+
+    CountDownLatch hookEntered = new CountDownLatch(1);
+    CountDownLatch releaseHook = new CountDownLatch(1);
+    consumer.beforeActivateHook =
+        () -> {
+          hookEntered.countDown();
+          try {
+            releaseHook.await();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+        };
+
+    closeConnection(cName);
+    assertThat(hookEntered.await(10, TimeUnit.SECONDS)).isTrue();
+    consumer.close();
+    releaseHook.countDown();
+
+    waitAtMost(() -> ((ResourceBase) consumer).state() == CLOSED);
+    // settle: nothing must move the state away from CLOSED afterwards
+    TestUtils.simulateActivity(Duration.ofMillis(500));
+    assertThat(((ResourceBase) consumer).state()).isEqualTo(CLOSED);
+    assertThat(transitions).noneMatch(t -> (t[0] == CLOSED || t[0] == CLOSING) && t[1] == OPEN);
+
+    waitAtMost(() -> ((ResourceBase) c).state() == OPEN);
+    c.close();
+  }
+
+  @Test
+  void consumerClosedDuringRecoveryDoesNotLeakNewReceiver(TestInfo info)
+      throws InterruptedException {
+    String cName = name(info);
+    connection.management().queue(this.q).declare();
+    Connection c =
+        ((AmqpConnectionBuilder) environment.connectionBuilder())
+            .name(cName)
+            .recovery()
+            .backOffDelayPolicy(backOffDelayPolicy)
+            .connectionBuilder()
+            .build();
+
+    AmqpConsumer consumer =
+        (AmqpConsumer) c.consumerBuilder().queue(this.q).messageHandler((ctx, msg) -> {}).build();
+
+    CountDownLatch hookEntered = new CountDownLatch(1);
+    CountDownLatch releaseHook = new CountDownLatch(1);
+    consumer.beforeActivateHook =
+        () -> {
+          hookEntered.countDown();
+          try {
+            releaseHook.await();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+        };
+
+    closeConnection(cName);
+    assertThat(hookEntered.await(10, TimeUnit.SECONDS)).isTrue();
+    consumer.close();
+    releaseHook.countDown();
+
+    waitAtMost(() -> consumer.state() == CLOSED);
+
+    Publisher publisher = connection.publisherBuilder().queue(this.q).build();
+    int messageCount = 10;
+    Sync publishSync = sync(messageCount);
+    IntStream.range(0, messageCount)
+        .forEach(ignored -> publisher.publish(publisher.message(), ctx -> publishSync.down()));
+    assertThat(publishSync).completes();
+
+    // settle: a leaked, credited receiver would consume these
+    TestUtils.simulateActivity(Duration.ofSeconds(1));
+    assertThat(connection.management().queueInfo(this.q).messageCount()).isEqualTo(messageCount);
+
+    waitAtMost(() -> ((ResourceBase) c).state() == OPEN);
+    c.close();
   }
 
   @ParameterizedTest

--- a/src/test/java/com/rabbitmq/client/amqp/impl/AmqpConsumerTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/AmqpConsumerTest.java
@@ -32,6 +32,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.rabbitmq.client.amqp.AmqpException;
 import com.rabbitmq.client.amqp.BackOffDelayPolicy;
 import com.rabbitmq.client.amqp.Connection;
 import com.rabbitmq.client.amqp.Consumer;
@@ -437,6 +438,17 @@ public class AmqpConsumerTest {
     IntStream.range(0, initialCredits)
         .forEach(ignored -> publisher.publish(publisher.message(), ctx -> {}));
     assertThat(consumeSync).completes();
+  }
+
+  @Test
+  void pauseThrowsOnClosedConsumer() {
+    connection.management().queue(this.q).declare();
+    Consumer consumer =
+        connection.consumerBuilder().queue(this.q).messageHandler((ctx, msg) -> {}).build();
+    consumer.close();
+
+    assertThatThrownBy(consumer::pause)
+        .isInstanceOf(AmqpException.AmqpResourceClosedException.class);
   }
 
   @Test

--- a/src/test/java/com/rabbitmq/client/amqp/impl/AmqpConsumerTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/AmqpConsumerTest.java
@@ -440,6 +440,62 @@ public class AmqpConsumerTest {
   }
 
   @Test
+  void pausedConsumerStaysPausedAfterRecovery(TestInfo info) throws InterruptedException {
+    String cName = name(info);
+    connection.management().queue(this.q).declare();
+    Connection c =
+        ((AmqpConnectionBuilder) environment.connectionBuilder())
+            .name(cName)
+            .recovery()
+            .backOffDelayPolicy(backOffDelayPolicy)
+            .connectionBuilder()
+            .build();
+    Publisher publisher = c.publisherBuilder().queue(this.q).build();
+
+    int initialCredits = 5;
+    int messageCount = initialCredits;
+    Sync consumeSync = sync(messageCount);
+    Sync recoveredSync = sync();
+    AmqpConsumer consumer =
+        (AmqpConsumer)
+            c.consumerBuilder()
+                .queue(this.q)
+                .initialCredits(initialCredits)
+                .listeners(recoveredListener(recoveredSync))
+                .messageHandler(
+                    (ctx, msg) -> {
+                      ctx.accept();
+                      consumeSync.down();
+                    })
+                .build();
+
+    consumer.pause();
+    assertThat(consumer.pauseStatus()).isEqualTo(AmqpConsumer.PauseStatus.PAUSED);
+
+    closeConnection(cName);
+    assertThat(recoveredSync).completes();
+    waitAtMost(() -> ((ResourceBase) c).state() == OPEN);
+    // the pause intent must survive recovery: no credit granted on the new generation
+    assertThat(consumer.pauseStatus()).isEqualTo(AmqpConsumer.PauseStatus.PAUSED);
+
+    Sync publishSync = sync(messageCount);
+    IntStream.range(0, messageCount)
+        .forEach(ignored -> publisher.publish(publisher.message(), ctx -> publishSync.down()));
+    assertThat(publishSync).completes();
+
+    // settle: a paused consumer must not consume anything after recovery
+    TestUtils.simulateActivity(Duration.ofSeconds(1));
+    assertThat(connection.management().queueInfo(this.q).messageCount()).isEqualTo(messageCount);
+
+    consumer.unpause();
+    assertThat(consumeSync).completes();
+
+    assertCreditInvariants(consumer, initialCredits);
+
+    c.close();
+  }
+
+  @Test
   void consumerClosedDuringRecoveryStaysClosed(TestInfo info) throws InterruptedException {
     String cName = name(info);
     connection.management().queue(this.q).declare();

--- a/src/test/java/com/rabbitmq/client/amqp/impl/AmqpConsumerTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/AmqpConsumerTest.java
@@ -402,6 +402,44 @@ public class AmqpConsumerTest {
   }
 
   @Test
+  void pauseInterruptedDoesNotLeaveConsumerPausing() throws InterruptedException {
+    connection.management().queue(this.q).declare();
+    Publisher publisher = connection.publisherBuilder().queue(this.q).build();
+
+    int initialCredits = 5;
+    Sync consumeSync = sync(initialCredits);
+    AmqpConsumer consumer =
+        (AmqpConsumer)
+            connection
+                .consumerBuilder()
+                .queue(this.q)
+                .initialCredits(initialCredits)
+                .messageHandler(
+                    (ctx, msg) -> {
+                      ctx.accept();
+                      consumeSync.down();
+                    })
+                .build();
+
+    Thread pausingThread = new Thread(consumer::pause);
+    pausingThread.start();
+    waitAtMost(consumer::pausedOrPausing);
+    pausingThread.interrupt();
+    pausingThread.join(TimeUnit.SECONDS.toMillis(10));
+
+    // the finally in pause() must settle the status even though the wait was interrupted,
+    // never leaving it at the unrecoverable PAUSING (unpause() cannot CAS out of it)
+    assertThat(consumer.pausedOrPausing()).isTrue();
+    assertThat(consumer.pauseStatus()).isEqualTo(AmqpConsumer.PauseStatus.PAUSED);
+
+    consumer.unpause();
+
+    IntStream.range(0, initialCredits)
+        .forEach(ignored -> publisher.publish(publisher.message(), ctx -> {}));
+    assertThat(consumeSync).completes();
+  }
+
+  @Test
   void consumerClosedDuringRecoveryStaysClosed(TestInfo info) throws InterruptedException {
     String cName = name(info);
     connection.management().queue(this.q).declare();

--- a/src/test/java/com/rabbitmq/client/amqp/impl/ResourceBaseTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/ResourceBaseTest.java
@@ -1,0 +1,76 @@
+// Copyright (c) 2024 Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+package com.rabbitmq.client.amqp.impl;
+
+import static com.rabbitmq.client.amqp.Resource.State.CLOSED;
+import static com.rabbitmq.client.amqp.Resource.State.CLOSING;
+import static com.rabbitmq.client.amqp.Resource.State.OPEN;
+import static com.rabbitmq.client.amqp.Resource.State.RECOVERING;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rabbitmq.client.amqp.Resource;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+import org.junit.jupiter.api.Test;
+
+public class ResourceBaseTest {
+
+  @Test
+  void stateDoesNotGoBackToOpenOnceClosing() {
+    List<Resource.State[]> transitions = new CopyOnWriteArrayList<>();
+    TestResource resource =
+        new TestResource(
+            List.of(
+                ctx ->
+                    transitions.add(
+                        new Resource.State[] {ctx.previousState(), ctx.currentState()})),
+            Runnable::run);
+
+    resource.state(OPEN);
+    resource.state(CLOSING);
+    resource.state(CLOSED);
+
+    // late writes from a concurrent recovery must not resurrect the closed resource
+    resource.state(OPEN);
+    resource.state(RECOVERING);
+
+    assertThat(resource.state()).isEqualTo(CLOSED);
+    assertThat(transitions)
+        .noneMatch(t -> t[0] == CLOSED && t[1] != CLOSED)
+        .noneMatch(t -> t[0] == CLOSING && t[1] != CLOSED);
+  }
+
+  @Test
+  void closedIsReachableFromClosing() {
+    TestResource resource = new TestResource(List.of(), Runnable::run);
+
+    resource.state(OPEN);
+    resource.state(CLOSING);
+    resource.state(CLOSED);
+
+    assertThat(resource.state()).isEqualTo(CLOSED);
+  }
+
+  private static class TestResource extends ResourceBase {
+
+    private TestResource(List<Resource.StateListener> listeners, Executor executor) {
+      super(listeners, executor);
+    }
+  }
+}


### PR DESCRIPTION
Behavior changes worth mentioning:
 * a paused consumer remains paused after recovery
 * `pause()` and `unpause()` now throw if the consumer is not open