### PR TITLE
Re-create binding entities in case of recovery failure

### DIFF
--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpUtils.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpUtils.java
@@ -43,6 +43,18 @@ final class AmqpUtils {
                   .contains(
                       "the exclusive property value does not match that of the original declaration");
 
+  static final Predicate<Exception> ENTITY_NOT_FOUND_EXCEPTION_PREDICATE =
+      e -> {
+        if (!(e instanceof AmqpException) || e.getMessage() == null) {
+          return false;
+        }
+        String message = e.getMessage();
+        return (message.contains("exchange") || message.contains("queue"))
+            && (message.contains("amqp:not-found")
+                || message.contains("no exchange")
+                || message.contains("no queue"));
+      };
+
   static Publisher.Status mapDeliveryState(DeliveryState in) {
     if (in.isAccepted()) {
       return Publisher.Status.ACCEPTED;

--- a/src/main/java/com/rabbitmq/client/amqp/impl/EntityRecovery.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/EntityRecovery.java
@@ -20,6 +20,7 @@ package com.rabbitmq.client.amqp.impl;
 import com.rabbitmq.client.amqp.Management;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,13 +65,16 @@ final class EntityRecovery {
           }
 
           @Override
-          public void visitBindings(Collection<RecordingTopologyListener.BindingSpec> bindings) {
+          public void visitBindings(
+              Collection<RecordingTopologyListener.BindingSpec> bindings,
+              List<RecordingTopologyListener.ExchangeSpec> exchanges,
+              List<RecordingTopologyListener.QueueSpec> queues) {
             if (bindings.isEmpty()) {
               LOGGER.debug("No bindings to recover");
             } else {
               LOGGER.debug("Recovering {} binding(s)...", bindings.size());
               for (RecordingTopologyListener.BindingSpec binding : bindings) {
-                recoverBinding(binding);
+                recoverBinding(binding, exchanges, queues);
               }
               LOGGER.debug("Bindings recovered");
             }
@@ -137,21 +141,12 @@ final class EntityRecovery {
     }
   }
 
-  private void recoverBinding(RecordingTopologyListener.BindingSpec binding) {
+  void recoverBinding(
+      RecordingTopologyListener.BindingSpec binding,
+      List<RecordingTopologyListener.ExchangeSpec> exchanges,
+      List<RecordingTopologyListener.QueueSpec> queues) {
     try {
-      Management.BindingSpecification spec =
-          this.connection
-              .managementNoCheck()
-              .binding()
-              .sourceExchange(binding.source())
-              .key(binding.key());
-      if (binding.toQueue()) {
-        spec.destinationQueue(binding.destination());
-      } else {
-        spec.destinationExchange(binding.destination());
-      }
-      binding.arguments().forEach(spec::argument);
-      spec.bind();
+      bind(binding);
     } catch (Exception e) {
       LOGGER.warn(
           "Error while recovering binding from {} to {} {} with binding key {}",
@@ -160,6 +155,54 @@ final class EntityRecovery {
           binding.destination(),
           binding.key(),
           e);
+      if (AmqpUtils.ENTITY_NOT_FOUND_EXCEPTION_PREDICATE.test(e)) {
+        // the exchange and/or queue involved in the binding may have been deleted
+        // (e.g. auto-delete exchange removed by the broker), try to recreate them
+        // and retry the binding once
+        try {
+          findExchange(exchanges, binding.source()).ifPresent(this::recoverExchange);
+          if (binding.toQueue()) {
+            findQueue(queues, binding.destination()).ifPresent(this::recoverQueue);
+          } else {
+            findExchange(exchanges, binding.destination()).ifPresent(this::recoverExchange);
+          }
+          bind(binding);
+        } catch (Exception retryException) {
+          LOGGER.warn(
+              "Error while retrying to recover binding from {} to {} {} with binding key {}",
+              binding.source(),
+              binding.toQueue() ? "queue" : "exchange",
+              binding.destination(),
+              binding.key(),
+              retryException);
+        }
+      }
     }
+  }
+
+  private void bind(RecordingTopologyListener.BindingSpec binding) {
+    Management.BindingSpecification spec =
+        this.connection
+            .managementNoCheck()
+            .binding()
+            .sourceExchange(binding.source())
+            .key(binding.key());
+    if (binding.toQueue()) {
+      spec.destinationQueue(binding.destination());
+    } else {
+      spec.destinationExchange(binding.destination());
+    }
+    binding.arguments().forEach(spec::argument);
+    spec.bind();
+  }
+
+  private static Optional<RecordingTopologyListener.ExchangeSpec> findExchange(
+      List<RecordingTopologyListener.ExchangeSpec> exchanges, String name) {
+    return exchanges.stream().filter(e -> e.name().equals(name)).findAny();
+  }
+
+  private static Optional<RecordingTopologyListener.QueueSpec> findQueue(
+      List<RecordingTopologyListener.QueueSpec> queues, String name) {
+    return queues.stream().filter(q -> q.name().equals(name)).findAny();
   }
 }

--- a/src/main/java/com/rabbitmq/client/amqp/impl/RecordingTopologyListener.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/RecordingTopologyListener.java
@@ -183,7 +183,7 @@ final class RecordingTopologyListener implements TopologyListener, AutoCloseable
     LOGGER.debug("Topology listener '{}' visitor, exchanges visited...", this.label);
     visitor.visitQueues(queueCopy.get());
     LOGGER.debug("Topology listener '{}' visitor, queues visited...", this.label);
-    visitor.visitBindings(bindingCopy.get());
+    visitor.visitBindings(bindingCopy.get(), exchangeCopy.get(), queueCopy.get());
     LOGGER.debug("Topology listener '{}' visitor, topology visited...", this.label);
   }
 
@@ -345,7 +345,8 @@ final class RecordingTopologyListener implements TopologyListener, AutoCloseable
 
     void visitQueues(List<QueueSpec> queues);
 
-    void visitBindings(Collection<BindingSpec> bindings);
+    void visitBindings(
+        Collection<BindingSpec> bindings, List<ExchangeSpec> exchanges, List<QueueSpec> queues);
   }
 
   // for test assertions

--- a/src/test/java/com/rabbitmq/client/amqp/impl/EntityRecoveryTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/EntityRecoveryTest.java
@@ -20,6 +20,7 @@ package com.rabbitmq.client.amqp.impl;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -32,6 +33,7 @@ import com.rabbitmq.client.amqp.Management;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,13 +45,22 @@ class EntityRecoveryTest {
 
   private static final String EXCLUSIVE_ACCESS_MSG_FORMAT =
       "Unexpected response code: 400 instead of 200, 201 (message: 'cannot obtain exclusive access to locked queue '%s' in vhost '/'. It could be originally declared on another connection or the exclusive property value does not match that of the original declaration.')";
+  private static final String NO_EXCHANGE_MSG_FORMAT =
+      "Unexpected response code: 400 instead of 204 (message: 'no exchange '%s' in vhost '/'')";
+  private static final String NO_QUEUE_MSG_FORMAT =
+      "Unexpected response code: 400 instead of 204 (message: 'no queue '%s' in vhost '/'')";
 
   @Mock AmqpConnection connection;
   @Mock RecordingTopologyListener topologyListener;
   @Mock Management management;
   @Mock Management.QueueSpecification queueSpec;
   @Mock Management.QueueInfo queueInfo;
+  @Mock Management.ExchangeSpecification exchangeSpec;
+  @Mock Management.BindingSpecification bindingSpec;
   @Mock RecordingTopologyListener.QueueSpec mockQueueSpec;
+  @Mock RecordingTopologyListener.ExchangeSpec mockExchangeSpec;
+  @Mock RecordingTopologyListener.ExchangeSpec mockSourceExchangeSpec;
+  @Mock RecordingTopologyListener.BindingSpec mockBindingSpec;
 
   EntityRecovery entityRecovery;
   BackOffDelayPolicy backOffDelayPolicy;
@@ -65,6 +76,19 @@ class EntityRecoveryTest {
     lenient().when(queueSpec.autoDelete(anyBoolean())).thenReturn(queueSpec);
     lenient().when(queueSpec.argument(anyString(), any())).thenReturn(queueSpec);
     lenient().when(queueSpec.declare()).thenReturn(queueInfo);
+
+    lenient().when(management.exchange()).thenReturn(exchangeSpec);
+    lenient().when(exchangeSpec.name(anyString())).thenReturn(exchangeSpec);
+    lenient().when(exchangeSpec.autoDelete(anyBoolean())).thenReturn(exchangeSpec);
+    lenient().when(exchangeSpec.type(anyString())).thenReturn(exchangeSpec);
+    lenient().when(exchangeSpec.argument(anyString(), any())).thenReturn(exchangeSpec);
+
+    lenient().when(management.binding()).thenReturn(bindingSpec);
+    lenient().when(bindingSpec.sourceExchange(anyString())).thenReturn(bindingSpec);
+    lenient().when(bindingSpec.destinationQueue(anyString())).thenReturn(bindingSpec);
+    lenient().when(bindingSpec.destinationExchange(anyString())).thenReturn(bindingSpec);
+    lenient().when(bindingSpec.key(anyString())).thenReturn(bindingSpec);
+    lenient().when(bindingSpec.argument(anyString(), any())).thenReturn(bindingSpec);
 
     entityRecovery = new EntityRecovery(connection, topologyListener);
   }
@@ -182,5 +206,132 @@ class EntityRecoveryTest {
     verify(queueSpec).argument("x-max-length", 1000);
     verify(queueSpec).argument("x-message-ttl", 60000);
     verify(queueSpec).declare();
+  }
+
+  @Test
+  void recoverBindingShouldSucceedOnFirstAttempt() {
+    when(mockBindingSpec.source()).thenReturn("ex");
+    when(mockBindingSpec.destination()).thenReturn("q");
+    when(mockBindingSpec.key()).thenReturn("foo");
+    when(mockBindingSpec.toQueue()).thenReturn(true);
+    when(mockBindingSpec.arguments()).thenReturn(Collections.emptyMap());
+
+    entityRecovery.recoverBinding(mockBindingSpec, List.of(), List.of());
+
+    verify(bindingSpec).bind();
+    verify(management, never()).exchange();
+    verify(management, never()).queue();
+  }
+
+  @Test
+  void recoverBindingShouldRecreateExchangeAndQueueOnNotFoundExceptionForQueueBinding() {
+    String exchangeName = "ex";
+    String queueName = "q";
+    when(mockBindingSpec.source()).thenReturn(exchangeName);
+    when(mockBindingSpec.destination()).thenReturn(queueName);
+    when(mockBindingSpec.key()).thenReturn("foo");
+    when(mockBindingSpec.toQueue()).thenReturn(true);
+    when(mockBindingSpec.arguments()).thenReturn(Collections.emptyMap());
+
+    AmqpException notFoundException =
+        new AmqpException(String.format(NO_EXCHANGE_MSG_FORMAT, exchangeName));
+    doThrow(notFoundException).doNothing().when(bindingSpec).bind();
+
+    when(mockExchangeSpec.name()).thenReturn(exchangeName);
+    when(mockExchangeSpec.autoDelete()).thenReturn(true);
+    when(mockExchangeSpec.type()).thenReturn("direct");
+    when(mockExchangeSpec.arguments()).thenReturn(Collections.emptyMap());
+
+    when(mockQueueSpec.name()).thenReturn(queueName);
+    when(mockQueueSpec.exclusive()).thenReturn(true);
+    when(mockQueueSpec.autoDelete()).thenReturn(false);
+    when(mockQueueSpec.arguments()).thenReturn(Collections.emptyMap());
+
+    entityRecovery.recoverBinding(
+        mockBindingSpec, List.of(mockExchangeSpec), List.of(mockQueueSpec));
+
+    verify(bindingSpec, times(2)).bind();
+    verify(exchangeSpec).declare();
+    verify(queueSpec).declare();
+  }
+
+  @Test
+  void recoverBindingShouldRecreateExchangesOnNotFoundExceptionForExchangeToExchangeBinding() {
+    String sourceExchange = "src-ex";
+    String destinationExchange = "dest-ex";
+    when(mockBindingSpec.source()).thenReturn(sourceExchange);
+    when(mockBindingSpec.destination()).thenReturn(destinationExchange);
+    when(mockBindingSpec.key()).thenReturn("foo");
+    when(mockBindingSpec.toQueue()).thenReturn(false);
+    when(mockBindingSpec.arguments()).thenReturn(Collections.emptyMap());
+
+    AmqpException notFoundException =
+        new AmqpException(String.format(NO_EXCHANGE_MSG_FORMAT, destinationExchange));
+    doThrow(notFoundException).doNothing().when(bindingSpec).bind();
+
+    when(mockSourceExchangeSpec.name()).thenReturn(sourceExchange);
+    when(mockSourceExchangeSpec.autoDelete()).thenReturn(false);
+    when(mockSourceExchangeSpec.type()).thenReturn("direct");
+    when(mockSourceExchangeSpec.arguments()).thenReturn(Collections.emptyMap());
+
+    when(mockExchangeSpec.name()).thenReturn(destinationExchange);
+    when(mockExchangeSpec.autoDelete()).thenReturn(true);
+    when(mockExchangeSpec.type()).thenReturn("direct");
+    when(mockExchangeSpec.arguments()).thenReturn(Collections.emptyMap());
+
+    entityRecovery.recoverBinding(
+        mockBindingSpec, List.of(mockSourceExchangeSpec, mockExchangeSpec), List.of());
+
+    verify(bindingSpec, times(2)).bind();
+    verify(exchangeSpec, times(2)).declare();
+    verify(management, never()).queue();
+  }
+
+  @Test
+  void recoverBindingShouldNotRetryOnOtherExceptions() {
+    when(mockBindingSpec.source()).thenReturn("ex");
+    when(mockBindingSpec.destination()).thenReturn("q");
+    when(mockBindingSpec.key()).thenReturn("foo");
+    when(mockBindingSpec.toQueue()).thenReturn(true);
+    when(mockBindingSpec.arguments()).thenReturn(Collections.emptyMap());
+
+    doThrow(new AmqpException("Some other error")).when(bindingSpec).bind();
+
+    entityRecovery.recoverBinding(
+        mockBindingSpec, List.of(mockExchangeSpec), List.of(mockQueueSpec));
+
+    verify(bindingSpec, times(1)).bind();
+    verify(management, never()).exchange();
+    verify(management, never()).queue();
+  }
+
+  @Test
+  void recoverBindingShouldGiveUpAfterOneRetry() {
+    String exchangeName = "ex";
+    String queueName = "q";
+    when(mockBindingSpec.source()).thenReturn(exchangeName);
+    when(mockBindingSpec.destination()).thenReturn(queueName);
+    when(mockBindingSpec.key()).thenReturn("foo");
+    when(mockBindingSpec.toQueue()).thenReturn(true);
+    when(mockBindingSpec.arguments()).thenReturn(Collections.emptyMap());
+
+    AmqpException notFoundException =
+        new AmqpException(String.format(NO_QUEUE_MSG_FORMAT, queueName));
+    doThrow(notFoundException).when(bindingSpec).bind();
+
+    when(mockExchangeSpec.name()).thenReturn(exchangeName);
+    when(mockExchangeSpec.autoDelete()).thenReturn(true);
+    when(mockExchangeSpec.type()).thenReturn("direct");
+    when(mockExchangeSpec.arguments()).thenReturn(Collections.emptyMap());
+
+    when(mockQueueSpec.name()).thenReturn(queueName);
+    when(mockQueueSpec.exclusive()).thenReturn(true);
+    when(mockQueueSpec.autoDelete()).thenReturn(false);
+    when(mockQueueSpec.arguments()).thenReturn(Collections.emptyMap());
+
+    entityRecovery.recoverBinding(
+        mockBindingSpec, List.of(mockExchangeSpec), List.of(mockQueueSpec));
+
+    verify(bindingSpec, times(2)).bind();
   }
 }


### PR DESCRIPTION
In case the recovery of a binding fails because one of its entities does not exist, this commit adds a step to re-create the entities (exchanges, queues) of the binding and the binding itself.

This should make the code more resilient for recovery with short recovery retry interval and should not do any harm as only the entities that have been recorded are retried and the creation is idempotent.