### PR TITLE
Add support for deferred messages on quorum queues

### DIFF
--- a/src/main/java/com/rabbitmq/client/amqp/Consumer.java
+++ b/src/main/java/com/rabbitmq/client/amqp/Consumer.java
@@ -59,6 +59,32 @@ public interface Consumer extends AutoCloseable, Resource {
   @Override
   void close();
 
+  /**
+   * Claim messages previously deferred with a {@link Context#delayedRetry(Duration, boolean,
+   * String)} token, so they are redelivered ahead of their scheduled delivery time.
+   *
+   * <p>A token may have been used for more than one message, in which case claiming it can deliver
+   * more than one message, oldest first. Claiming an unknown token has no effect: it is silently
+   * ignored by the broker. A claim does not grant extra credit: claimed messages are delivered as
+   * the consumer's existing credit allows.
+   *
+   * <p>Claims do not survive connection recovery: the application must claim tokens again after the
+   * consumer recovers.
+   *
+   * <p><b>Only quorum queues support deferral tokens.</b>
+   *
+   * <p><b>Requires RabbitMQ 4.4 or more.</b>
+   *
+   * @param tokens the tokens to claim
+   * @throws AmqpException if the consumer is not open
+   * @throws AmqpException if the queue this consumer is attached to does not support deferral
+   *     tokens
+   * @see Context#delayedRetry(Duration, boolean, String)
+   * @see Context#delayedRetry(Instant, boolean, String)
+   * @since 1.6.0
+   */
+  void claimDeferred(String... tokens);
+
   /** Contract to process a message. */
   @FunctionalInterface
   interface MessageHandler {
@@ -262,6 +288,72 @@ public interface Consumer extends AutoCloseable, Resource {
      *     RabbitMQ</a>
      */
     void delayedRetry(Instant deliveryTime, boolean deliveryFailed);
+
+    /**
+     * Requeue the message for redelivery after the specified delay, and park it under a deferral
+     * token so it can also be retrieved early with {@link Consumer#claimDeferred(String...)}.
+     *
+     * <p>This maps to the AMQP 1.0 <code>
+     * modified{delivery-failed = deliveryFailed, undeliverable-here = false}</code> outcome with
+     * the <code>x-opt-delivery-time</code> annotation set to <code>now + delay</code> and the
+     * <code>x-opt-deferral-token</code> annotation set to <code>deferralToken</code>.
+     *
+     * <p>The token is honoured only because a delivery time is also set: a deferral token cannot be
+     * supplied without one, since the broker would otherwise silently ignore it. The message still
+     * becomes available at its delivery time even if the token is never claimed. If the token has
+     * already been used for another message, claiming it delivers both, oldest first. The token is
+     * readable on the redelivered message through its <code>x-opt-deferral-token
+     * </code> annotation.
+     *
+     * <p><b>Only quorum queues support deferral tokens.</b>
+     *
+     * <p><b>Requires RabbitMQ 4.4 or more.</b>
+     *
+     * @param delay delivery delay from now
+     * @param deliveryFailed if true, the delivery count of the message is incremented
+     * @param deferralToken the token the message is parked under, at most 256 UTF-8 bytes
+     * @see <a
+     *     href="https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-modified">AMQP
+     *     1.0 <code>modified</code> outcome</a>
+     * @see <a href="https://www.rabbitmq.com/docs/amqp#modified-outcome">Modified Outcome Support
+     *     in RabbitMQ</a>
+     * @see Consumer#claimDeferred(String...)
+     * @since 1.6.0
+     */
+    void delayedRetry(Duration delay, boolean deliveryFailed, String deferralToken);
+
+    /**
+     * Requeue the message for redelivery at the specified time, and park it under a deferral token
+     * so it can also be retrieved early with {@link Consumer#claimDeferred(String...)}.
+     *
+     * <p>This maps to the AMQP 1.0 <code>
+     * modified{delivery-failed = deliveryFailed, undeliverable-here = false}</code> outcome with
+     * the <code>x-opt-delivery-time</code> annotation set to the specified time and the <code>
+     * x-opt-deferral-token</code> annotation set to <code>deferralToken</code>.
+     *
+     * <p>The token is honoured only if <code>deliveryTime</code> is in the future: a deferral token
+     * cannot be supplied without one, since the broker would otherwise silently ignore it. The
+     * message still becomes available at its delivery time even if the token is never claimed. If
+     * the token has already been used for another message, claiming it delivers both, oldest first.
+     * The token is readable on the redelivered message through its <code>
+     * x-opt-deferral-token</code> annotation.
+     *
+     * <p><b>Only quorum queues support deferral tokens.</b>
+     *
+     * <p><b>Requires RabbitMQ 4.4 or more.</b>
+     *
+     * @param deliveryTime absolute delivery time, must be in the future
+     * @param deliveryFailed if true, the delivery count of the message is incremented
+     * @param deferralToken the token the message is parked under, at most 256 UTF-8 bytes
+     * @see <a
+     *     href="https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-modified">AMQP
+     *     1.0 <code>modified</code> outcome</a>
+     * @see <a href="https://www.rabbitmq.com/docs/amqp#modified-outcome">Modified Outcome Support
+     *     in RabbitMQ</a>
+     * @see Consumer#claimDeferred(String...)
+     * @since 1.6.0
+     */
+    void delayedRetry(Instant deliveryTime, boolean deliveryFailed, String deferralToken);
 
     /**
      * Create a batch context to accumulate message contexts and settle them at once.

--- a/src/main/java/com/rabbitmq/client/amqp/Consumer.java
+++ b/src/main/java/com/rabbitmq/client/amqp/Consumer.java
@@ -60,8 +60,8 @@ public interface Consumer extends AutoCloseable, Resource {
   void close();
 
   /**
-   * Claim messages previously deferred with a {@link Context#delayedRetry(Duration, boolean,
-   * String)} token, so they are redelivered ahead of their scheduled delivery time.
+   * Claim messages previously deferred with a {@link Context#defer(String, java.time.Duration)}
+   * token, so they are redelivered ahead of their scheduled delivery time.
    *
    * <p>A token may have been used for more than one message, in which case claiming it can deliver
    * more than one message, oldest first. Claiming an unknown token has no effect: it is silently
@@ -75,12 +75,14 @@ public interface Consumer extends AutoCloseable, Resource {
    *
    * <p><b>Requires RabbitMQ 4.4 or more.</b>
    *
+   * <p>This is an experimental API, subject to change.
+   *
    * @param tokens the tokens to claim
    * @throws AmqpException if the consumer is not open
    * @throws AmqpException if the queue this consumer is attached to does not support deferral
    *     tokens
-   * @see Context#delayedRetry(Duration, boolean, String)
-   * @see Context#delayedRetry(Instant, boolean, String)
+   * @see Context#defer(String, java.time.Duration)
+   * @see Context#defer(String, java.time.Instant)
    * @since 1.6.0
    */
   void claimDeferred(String... tokens);
@@ -309,6 +311,8 @@ public interface Consumer extends AutoCloseable, Resource {
      *
      * <p><b>Requires RabbitMQ 4.4 or more.</b>
      *
+     * <p>This is an experimental API, subject to change.
+     *
      * @param deferralToken the token the message is parked under, at most 256 UTF-8 bytes
      * @param delay delivery delay from now
      * @see <a
@@ -340,6 +344,8 @@ public interface Consumer extends AutoCloseable, Resource {
      * <p><b>Only quorum queues support deferral tokens.</b>
      *
      * <p><b>Requires RabbitMQ 4.4 or more.</b>
+     *
+     * <p>This is an experimental API, subject to change.
      *
      * @param deferralToken the token the message is parked under, at most 256 UTF-8 bytes
      * @param deliveryTime absolute delivery time, must be in the future

--- a/src/main/java/com/rabbitmq/client/amqp/Consumer.java
+++ b/src/main/java/com/rabbitmq/client/amqp/Consumer.java
@@ -294,9 +294,9 @@ public interface Consumer extends AutoCloseable, Resource {
      * token so it can also be retrieved early with {@link Consumer#claimDeferred(String...)}.
      *
      * <p>This maps to the AMQP 1.0 <code>
-     * modified{delivery-failed = deliveryFailed, undeliverable-here = false}</code> outcome with
-     * the <code>x-opt-delivery-time</code> annotation set to <code>now + delay</code> and the
-     * <code>x-opt-deferral-token</code> annotation set to <code>deferralToken</code>.
+     * modified{delivery-failed = false, undeliverable-here = false}</code> outcome with the <code>
+     * x-opt-delivery-time</code> annotation set to <code>now + delay</code> and the <code>
+     * x-opt-deferral-token</code> annotation set to <code>deferralToken</code>.
      *
      * <p>The token is honoured only because a delivery time is also set: a deferral token cannot be
      * supplied without one, since the broker would otherwise silently ignore it. The message still
@@ -309,9 +309,8 @@ public interface Consumer extends AutoCloseable, Resource {
      *
      * <p><b>Requires RabbitMQ 4.4 or more.</b>
      *
-     * @param delay delivery delay from now
-     * @param deliveryFailed if true, the delivery count of the message is incremented
      * @param deferralToken the token the message is parked under, at most 256 UTF-8 bytes
+     * @param delay delivery delay from now
      * @see <a
      *     href="https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-modified">AMQP
      *     1.0 <code>modified</code> outcome</a>
@@ -320,15 +319,15 @@ public interface Consumer extends AutoCloseable, Resource {
      * @see Consumer#claimDeferred(String...)
      * @since 1.6.0
      */
-    void delayedRetry(Duration delay, boolean deliveryFailed, String deferralToken);
+    void defer(String deferralToken, Duration delay);
 
     /**
      * Requeue the message for redelivery at the specified time, and park it under a deferral token
      * so it can also be retrieved early with {@link Consumer#claimDeferred(String...)}.
      *
      * <p>This maps to the AMQP 1.0 <code>
-     * modified{delivery-failed = deliveryFailed, undeliverable-here = false}</code> outcome with
-     * the <code>x-opt-delivery-time</code> annotation set to the specified time and the <code>
+     * modified{delivery-failed = false, undeliverable-here = false}</code> outcome with the <code>
+     * x-opt-delivery-time</code> annotation set to the specified time and the <code>
      * x-opt-deferral-token</code> annotation set to <code>deferralToken</code>.
      *
      * <p>The token is honoured only if <code>deliveryTime</code> is in the future: a deferral token
@@ -342,9 +341,8 @@ public interface Consumer extends AutoCloseable, Resource {
      *
      * <p><b>Requires RabbitMQ 4.4 or more.</b>
      *
-     * @param deliveryTime absolute delivery time, must be in the future
-     * @param deliveryFailed if true, the delivery count of the message is incremented
      * @param deferralToken the token the message is parked under, at most 256 UTF-8 bytes
+     * @param deliveryTime absolute delivery time, must be in the future
      * @see <a
      *     href="https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-modified">AMQP
      *     1.0 <code>modified</code> outcome</a>
@@ -353,7 +351,7 @@ public interface Consumer extends AutoCloseable, Resource {
      * @see Consumer#claimDeferred(String...)
      * @since 1.6.0
      */
-    void delayedRetry(Instant deliveryTime, boolean deliveryFailed, String deferralToken);
+    void defer(String deferralToken, Instant deliveryTime);
 
     /**
      * Create a batch context to accumulate message contexts and settle them at once.

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConsumer.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConsumer.java
@@ -39,6 +39,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedHashMap;
@@ -70,6 +71,7 @@ import org.apache.qpid.protonj2.engine.impl.ProtonLinkCreditState;
 import org.apache.qpid.protonj2.engine.impl.ProtonReceiver;
 import org.apache.qpid.protonj2.engine.impl.ProtonSessionIncomingWindow;
 import org.apache.qpid.protonj2.types.DescribedType;
+import org.apache.qpid.protonj2.types.Symbol;
 import org.apache.qpid.protonj2.types.messaging.Accepted;
 import org.apache.qpid.protonj2.types.messaging.Modified;
 import org.apache.qpid.protonj2.types.messaging.Rejected;
@@ -100,6 +102,9 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
 
   private static final AtomicLong ID_SEQUENCE = new AtomicLong(0);
   private static final Consumer.Context PRE_SETTLED_CONTEXT = new PreSettledContext();
+  private static final String DEFERRAL_TOKENS_CAPABILITY = "rabbitmq:deferral-tokens";
+  private static final Symbol DEFERRAL_TOKENS = Symbol.valueOf(DEFERRAL_TOKENS_CAPABILITY);
+  private static final int MAX_TOKENS_PER_FLOW = 256; // ?MAX_DEFERRAL_TOKENS on the broker side
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AmqpConsumer.class);
 
@@ -234,6 +239,39 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
   @Override
   public long unsettledMessageCount() {
     return this.link.unsettled.get();
+  }
+
+  @Override
+  public void claimDeferred(String... tokens) {
+    checkOpen();
+    notNull(tokens, "Tokens");
+    Link claimLink = this.link;
+    if (!claimLink.deferralSupported()) {
+      throw new AmqpException(
+          "The queue this consumer is attached to does not support deferral tokens "
+              + "(only quorum queues do)");
+    }
+    for (String token : tokens) {
+      Utils.checkDeferralToken(token);
+    }
+    for (int offset = 0; offset < tokens.length; offset += MAX_TOKENS_PER_FLOW) {
+      String[] batch =
+          Arrays.copyOfRange(tokens, offset, Math.min(offset + MAX_TOKENS_PER_FLOW, tokens.length));
+      onExecutor(
+          claimLink,
+          () -> {
+            if (!claimLink.isValid()) {
+              // generation superseded by recovery; claims do not survive it anyway
+              return;
+            }
+            try {
+              claimLink.protonReceiver.writeFlowWithProperties(
+                  Collections.singletonMap(DEFERRAL_TOKENS, batch));
+            } catch (Exception e) {
+              LOGGER.debug("Error while claiming deferred messages", e);
+            }
+          });
+    }
   }
 
   @Override
@@ -451,6 +489,7 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
   private Link buildLink(ClientReceiver receiver, AtomicReference<Link> holder) {
     try {
       Scheduler executor = receiver.executor();
+      boolean deferralSupported = deferralSupported(receiver);
       CountDownLatch publishedLatch = new CountDownLatch(1);
       executor.execute(
           () -> {
@@ -461,7 +500,8 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
                     executor,
                     protonReceiver,
                     protonReceiver.getCreditState(),
-                    protonReceiver.sessionWindow());
+                    protonReceiver.sessionWindow(),
+                    deferralSupported);
 
             EventHandler<org.apache.qpid.protonj2.engine.Receiver> eventHandler =
                 protonReceiver.linkCreditUpdatedHandler();
@@ -484,6 +524,18 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
       return holder.get();
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  // the receiver capability is advertised on the attach response, so it is available as soon as
+  // the native receiver has opened, before buildLink hops onto the proton executor
+  private static boolean deferralSupported(ClientReceiver receiver) {
+    try {
+      String[] capabilities = receiver.offeredCapabilities();
+      return capabilities != null
+          && Arrays.asList(capabilities).contains(DEFERRAL_TOKENS_CAPABILITY);
+    } catch (ClientException e) {
+      return false;
     }
   }
 
@@ -691,18 +743,26 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
     private final AtomicLong unsettled = new AtomicLong(0);
     private int pendingWorkItems; // I2: proton-executor-confined, plain int
     private volatile boolean current = true; // false once superseded
+    // set once, from the attach response, before this Link is published
+    private final boolean deferralSupported;
 
     private Link(
         ClientReceiver receiver,
         Scheduler executor,
         ProtonReceiver protonReceiver,
         ProtonLinkCreditState creditState,
-        ProtonSessionIncomingWindow sessionWindow) {
+        ProtonSessionIncomingWindow sessionWindow,
+        boolean deferralSupported) {
       this.receiver = receiver;
       this.executor = executor;
       this.protonReceiver = protonReceiver;
       this.creditState = creditState;
       this.sessionWindow = sessionWindow;
+      this.deferralSupported = deferralSupported;
+    }
+
+    private boolean deferralSupported() {
+      return this.deferralSupported;
     }
 
     boolean isValid() {
@@ -786,6 +846,26 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
       notNull(deliveryTime, "Delivery time");
       Map<String, Object> annotations =
           Collections.singletonMap(AmqpUtils.ANN_DELIVERY_TIME, Date.from(deliveryTime));
+      this.requeue(annotations, deliveryFailed);
+    }
+
+    @Override
+    public void delayedRetry(Duration delay, boolean deliveryFailed, String deferralToken) {
+      notNull(delay, "Delay");
+      this.delayedRetry(Instant.now().plus(delay), deliveryFailed, deferralToken);
+    }
+
+    @Override
+    public void delayedRetry(Instant deliveryTime, boolean deliveryFailed, String deferralToken) {
+      notNull(deliveryTime, "Delivery time");
+      Utils.checkDeferralToken(deferralToken);
+      Utils.checkDeferralDeliveryTime(deliveryTime);
+      Map<String, Object> annotations =
+          Map.of(
+              AmqpUtils.ANN_DELIVERY_TIME,
+              Date.from(deliveryTime),
+              AmqpUtils.ANN_DEFERRAL_TOKEN,
+              deferralToken);
       this.requeue(annotations, deliveryFailed);
     }
 
@@ -933,6 +1013,25 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
     }
 
     @Override
+    public void delayedRetry(Duration delay, boolean deliveryFailed, String deferralToken) {
+      this.delayedRetry(Instant.now().plus(delay), deliveryFailed, deferralToken);
+    }
+
+    @Override
+    public void delayedRetry(Instant deliveryTime, boolean deliveryFailed, String deferralToken) {
+      notNull(deliveryTime, "Delivery time");
+      Utils.checkDeferralToken(deferralToken);
+      Utils.checkDeferralDeliveryTime(deliveryTime);
+      Map<String, Object> annotations =
+          Map.of(
+              AmqpUtils.ANN_DELIVERY_TIME,
+              Date.from(deliveryTime),
+              AmqpUtils.ANN_DEFERRAL_TOKEN,
+              deferralToken);
+      this.requeue(annotations, deliveryFailed);
+    }
+
+    @Override
     public BatchContext batch(int batchSizeHint) {
       return this;
     }
@@ -1048,6 +1147,16 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
 
     @Override
     public void delayedRetry(Instant deliveryTime) {
+      throw new UnsupportedOperationException("auto-settle on, message is already disposed");
+    }
+
+    @Override
+    public void delayedRetry(Duration delay, boolean deliveryFailed, String deferralToken) {
+      throw new UnsupportedOperationException("auto-settle on, message is already disposed");
+    }
+
+    @Override
+    public void delayedRetry(Instant deliveryTime, boolean deliveryFailed, String deferralToken) {
       throw new UnsupportedOperationException("auto-settle on, message is already disposed");
     }
 

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConsumer.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpConsumer.java
@@ -850,13 +850,13 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
     }
 
     @Override
-    public void delayedRetry(Duration delay, boolean deliveryFailed, String deferralToken) {
+    public void defer(String deferralToken, Duration delay) {
       notNull(delay, "Delay");
-      this.delayedRetry(Instant.now().plus(delay), deliveryFailed, deferralToken);
+      this.defer(deferralToken, Instant.now().plus(delay));
     }
 
     @Override
-    public void delayedRetry(Instant deliveryTime, boolean deliveryFailed, String deferralToken) {
+    public void defer(String deferralToken, Instant deliveryTime) {
       notNull(deliveryTime, "Delivery time");
       Utils.checkDeferralToken(deferralToken);
       Utils.checkDeferralDeliveryTime(deliveryTime);
@@ -866,7 +866,7 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
               Date.from(deliveryTime),
               AmqpUtils.ANN_DEFERRAL_TOKEN,
               deferralToken);
-      this.requeue(annotations, deliveryFailed);
+      this.requeue(annotations, false);
     }
 
     @Override
@@ -1013,12 +1013,13 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
     }
 
     @Override
-    public void delayedRetry(Duration delay, boolean deliveryFailed, String deferralToken) {
-      this.delayedRetry(Instant.now().plus(delay), deliveryFailed, deferralToken);
+    public void defer(String deferralToken, Duration delay) {
+      notNull(delay, "Delay");
+      this.defer(deferralToken, Instant.now().plus(delay));
     }
 
     @Override
-    public void delayedRetry(Instant deliveryTime, boolean deliveryFailed, String deferralToken) {
+    public void defer(String deferralToken, Instant deliveryTime) {
       notNull(deliveryTime, "Delivery time");
       Utils.checkDeferralToken(deferralToken);
       Utils.checkDeferralDeliveryTime(deliveryTime);
@@ -1028,7 +1029,7 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
               Date.from(deliveryTime),
               AmqpUtils.ANN_DEFERRAL_TOKEN,
               deferralToken);
-      this.requeue(annotations, deliveryFailed);
+      this.requeue(annotations, false);
     }
 
     @Override
@@ -1151,12 +1152,12 @@ final class AmqpConsumer extends ResourceBase implements Consumer {
     }
 
     @Override
-    public void delayedRetry(Duration delay, boolean deliveryFailed, String deferralToken) {
+    public void defer(String deferralToken, Duration delay) {
       throw new UnsupportedOperationException("auto-settle on, message is already disposed");
     }
 
     @Override
-    public void delayedRetry(Instant deliveryTime, boolean deliveryFailed, String deferralToken) {
+    public void defer(String deferralToken, Instant deliveryTime) {
       throw new UnsupportedOperationException("auto-settle on, message is already disposed");
     }
 

--- a/src/main/java/com/rabbitmq/client/amqp/impl/AmqpUtils.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/AmqpUtils.java
@@ -33,6 +33,7 @@ final class AmqpUtils {
   private AmqpUtils() {}
 
   static final String ANN_DELIVERY_TIME = "x-opt-delivery-time";
+  static final String ANN_DEFERRAL_TOKEN = "x-opt-deferral-token";
 
   static final Predicate<Exception> EXCLUSIVE_ACCESS_EXCEPTION_PREDICATE =
       e ->

--- a/src/main/java/com/rabbitmq/client/amqp/impl/Utils.java
+++ b/src/main/java/com/rabbitmq/client/amqp/impl/Utils.java
@@ -27,6 +27,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Map;
@@ -146,6 +147,30 @@ final class Utils {
   static void validateMessageAnnotationKey(String key) {
     if (!key.startsWith("x-")) {
       throw new IllegalArgumentException("Message annotation keys must start with 'x-': " + key);
+    }
+  }
+
+  // ?MAX_DEFERRAL_TOKEN_SIZE on the broker side, expressed in UTF-8 bytes, not characters
+  private static final int MAX_DEFERRAL_TOKEN_SIZE = 256;
+
+  static void checkDeferralToken(String token) {
+    if (token == null || token.isEmpty()) {
+      throw new IllegalArgumentException("Deferral token must not be null or empty");
+    }
+    int size = token.getBytes(StandardCharsets.UTF_8).length;
+    if (size > MAX_DEFERRAL_TOKEN_SIZE) {
+      throw new IllegalArgumentException(
+          "Deferral token must be at most "
+              + MAX_DEFERRAL_TOKEN_SIZE
+              + " bytes (UTF-8), got "
+              + size);
+    }
+  }
+
+  static void checkDeferralDeliveryTime(Instant deliveryTime) {
+    if (!deliveryTime.isAfter(Instant.now())) {
+      throw new IllegalArgumentException(
+          "Delivery time must be in the future when a deferral token is set: " + deliveryTime);
     }
   }
 

--- a/src/main/qpid/org/apache/qpid/protonj2/engine/impl/ProtonReceiver.java
+++ b/src/main/qpid/org/apache/qpid/protonj2/engine/impl/ProtonReceiver.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -33,6 +34,7 @@ import org.apache.qpid.protonj2.engine.Session;
 import org.apache.qpid.protonj2.engine.exceptions.ProtocolViolationException;
 import org.apache.qpid.protonj2.engine.util.DeliveryIdTracker;
 import org.apache.qpid.protonj2.engine.util.UnsettledMap;
+import org.apache.qpid.protonj2.types.Symbol;
 import org.apache.qpid.protonj2.types.UnsignedInteger;
 import org.apache.qpid.protonj2.types.transport.Attach;
 import org.apache.qpid.protonj2.types.transport.DeliveryState;
@@ -66,6 +68,10 @@ public class ProtonReceiver extends ProtonLink<Receiver> implements Receiver {
 
     private DeliveryState defaultDeliveryState;
     private LinkCreditState drainStateSnapshot;
+
+    // One-shot properties for the next outgoing flow only, e.g. RabbitMQ deferral-token claims.
+    // Never leaks to a later, unrelated flow.
+    private Map<Symbol, Object> nextFlowProperties;
 
     /**
      * Create a new {@link Receiver} instance with the given {@link Session} parent.
@@ -119,6 +125,21 @@ public class ProtonReceiver extends ProtonLink<Receiver> implements Receiver {
             getCreditState().incrementCredit(credit);
             if (isLocallyOpen() && wasLocalAttachSent()) {
                 sessionWindow.writeFlow(this);
+            }
+        }
+
+        return this;
+    }
+
+    public ProtonReceiver writeFlowWithProperties(Map<Symbol, Object> properties) {
+        checkLinkOperable("Cannot write flow");
+
+        if (isLocallyOpen() && wasLocalAttachSent()) {
+            this.nextFlowProperties = properties;
+            try {
+                sessionWindow.writeFlow(this);
+            } finally {
+                this.nextFlowProperties = null;
             }
         }
 
@@ -469,6 +490,9 @@ public class ProtonReceiver extends ProtonLink<Receiver> implements Receiver {
         flow.setDrain(isDraining());
         if (getCreditState().isEcho()) {
             flow.setEcho(true);
+        }
+        if (nextFlowProperties != null) {
+            flow.setProperties(nextFlowProperties);
         }
 
         return this;

--- a/src/test/java/com/rabbitmq/client/amqp/impl/BatchDispositionTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/BatchDispositionTest.java
@@ -177,6 +177,16 @@ public class BatchDispositionTest {
       dispose();
     }
 
+    @Override
+    public void delayedRetry(Duration delay, boolean deliveryFailed, String deferralToken) {
+      dispose();
+    }
+
+    @Override
+    public void delayedRetry(Instant deliveryTime, boolean deliveryFailed, String deferralToken) {
+      dispose();
+    }
+
     private void dispose() {
       dispositionFrameCount.inc();
       dispositionRangeSize.update(1);
@@ -255,6 +265,16 @@ public class BatchDispositionTest {
 
     @Override
     public void delayedRetry(Instant deliveryTime, boolean deliveryFailed) {
+      dispose();
+    }
+
+    @Override
+    public void delayedRetry(Duration delay, boolean deliveryFailed, String deferralToken) {
+      dispose();
+    }
+
+    @Override
+    public void delayedRetry(Instant deliveryTime, boolean deliveryFailed, String deferralToken) {
       dispose();
     }
 

--- a/src/test/java/com/rabbitmq/client/amqp/impl/BatchDispositionTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/BatchDispositionTest.java
@@ -178,12 +178,12 @@ public class BatchDispositionTest {
     }
 
     @Override
-    public void delayedRetry(Duration delay, boolean deliveryFailed, String deferralToken) {
+    public void defer(String deferralToken, Duration delay) {
       dispose();
     }
 
     @Override
-    public void delayedRetry(Instant deliveryTime, boolean deliveryFailed, String deferralToken) {
+    public void defer(String deferralToken, Instant deliveryTime) {
       dispose();
     }
 
@@ -269,12 +269,12 @@ public class BatchDispositionTest {
     }
 
     @Override
-    public void delayedRetry(Duration delay, boolean deliveryFailed, String deferralToken) {
+    public void defer(String deferralToken, Duration delay) {
       dispose();
     }
 
     @Override
-    public void delayedRetry(Instant deliveryTime, boolean deliveryFailed, String deferralToken) {
+    public void defer(String deferralToken, Instant deliveryTime) {
       dispose();
     }
 

--- a/src/test/java/com/rabbitmq/client/amqp/impl/DelayedRetryTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/DelayedRetryTest.java
@@ -19,22 +19,28 @@ package com.rabbitmq.client.amqp.impl;
 
 import static com.rabbitmq.client.amqp.Management.DelayedRetryType.ALL;
 import static com.rabbitmq.client.amqp.impl.Assertions.assertThat;
+import static com.rabbitmq.client.amqp.impl.TestConditions.BrokerVersion.RABBITMQ_4_4_0;
 import static com.rabbitmq.client.amqp.impl.TestUtils.waitAtMost;
 import static java.time.Duration.ofMillis;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.rabbitmq.client.amqp.AmqpException;
 import com.rabbitmq.client.amqp.Connection;
 import com.rabbitmq.client.amqp.Consumer;
 import com.rabbitmq.client.amqp.Management;
 import com.rabbitmq.client.amqp.Message;
 import com.rabbitmq.client.amqp.Publisher;
+import com.rabbitmq.client.amqp.impl.TestConditions.BrokerVersionAtLeast;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Queue;
+import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -237,6 +243,215 @@ public class DelayedRetryTest {
 
     Message redelivered = messages.poll();
     assertThat(redelivered).isNotNull().hasDeliveryCount(deliveryFailed ? 1L : 0L);
+    waitAtMost(() -> management.queueInfo(q).messageCount() == 0);
+  }
+
+  @Test
+  @BrokerVersionAtLeast(RABBITMQ_4_4_0)
+  void deferredMessageCanBeClaimedBeforeItsDeliveryTime() {
+    this.management.queue().name(q).quorum().queue().declare();
+
+    Publisher publisher = this.connection.publisherBuilder().queue(q).build();
+    String token = "token-" + UUID.randomUUID();
+    AtomicInteger deliveryCount = new AtomicInteger();
+    Queue<Message> messages = new ArrayBlockingQueue<>(1);
+    TestUtils.Sync parkedSync = TestUtils.sync();
+    TestUtils.Sync redeliveredSync = TestUtils.sync();
+
+    Consumer consumer =
+        this.connection
+            .consumerBuilder()
+            .queue(q)
+            .messageHandler(
+                (context, message) -> {
+                  if (deliveryCount.incrementAndGet() == 1) {
+                    context.delayedRetry(ofMillis(60_000), false, token);
+                    parkedSync.down();
+                  } else {
+                    messages.offer(message);
+                    context.accept();
+                    redeliveredSync.down();
+                  }
+                })
+            .build();
+
+    publisher.publish(publisher.message(), ctx -> {});
+    assertThat(parkedSync).completes();
+
+    // the far-future delivery time means only claiming the token, not the default
+    // credit-driven flow, can bring the message back within the test timeout
+    consumer.claimDeferred(token);
+    assertThat(redeliveredSync).completes();
+
+    Message redelivered = messages.poll();
+    assertThat(redelivered).isNotNull().hasAnnotation("x-opt-deferral-token", token);
+
+    consumer.close();
+  }
+
+  @Test
+  @BrokerVersionAtLeast(RABBITMQ_4_4_0)
+  void batchDeferralParksMessagesUnderSharedTokenAndOneClaimReturnsBoth() {
+    this.management.queue().name(q).quorum().queue().declare();
+
+    Publisher publisher = this.connection.publisherBuilder().queue(q).build();
+    String token = "token-" + UUID.randomUUID();
+    AtomicInteger deliveryCount = new AtomicInteger();
+    AtomicReference<Consumer.BatchContext> batchRef = new AtomicReference<>();
+    Queue<Message> redelivered = new ArrayBlockingQueue<>(2);
+    TestUtils.Sync parkedSync = TestUtils.sync();
+    TestUtils.Sync redeliveredSync = TestUtils.sync(2);
+
+    Consumer consumer =
+        this.connection
+            .consumerBuilder()
+            .queue(q)
+            .messageHandler(
+                (context, message) -> {
+                  if (deliveryCount.incrementAndGet() <= 2) {
+                    Consumer.BatchContext batch =
+                        batchRef.get() == null ? context.batch(2) : batchRef.get();
+                    batchRef.set(batch);
+                    batch.add(context);
+                    if (batch.size() == 2) {
+                      batch.delayedRetry(ofMillis(60_000), false, token);
+                      parkedSync.down();
+                    }
+                  } else {
+                    redelivered.offer(message);
+                    context.accept();
+                    redeliveredSync.down();
+                  }
+                })
+            .build();
+
+    publisher.publish(publisher.message(), ctx -> {});
+    publisher.publish(publisher.message(), ctx -> {});
+    assertThat(parkedSync).completes();
+
+    consumer.claimDeferred(token);
+    assertThat(redeliveredSync).completes();
+    assertThat(redelivered).hasSize(2);
+
+    consumer.close();
+  }
+
+  @Test
+  @BrokerVersionAtLeast(RABBITMQ_4_4_0)
+  void claimedTokenWithSeveralMessagesDeliversThemAsCreditAllowsWithoutReclaiming() {
+    this.management.queue().name(q).quorum().queue().declare();
+
+    Publisher publisher = this.connection.publisherBuilder().queue(q).build();
+    String token = "token-" + UUID.randomUUID();
+    AtomicInteger deliveryCount = new AtomicInteger();
+    Queue<Message> redelivered = new ArrayBlockingQueue<>(2);
+    TestUtils.Sync parkedSync = TestUtils.sync(2);
+    TestUtils.Sync redeliveredSync = TestUtils.sync(2);
+
+    Consumer consumer =
+        this.connection
+            .consumerBuilder()
+            .queue(q)
+            .initialCredits(1)
+            .messageHandler(
+                (context, message) -> {
+                  if (deliveryCount.incrementAndGet() <= 2) {
+                    context.delayedRetry(ofMillis(60_000), false, token);
+                    parkedSync.down();
+                  } else {
+                    redelivered.offer(message);
+                    context.accept();
+                    redeliveredSync.down();
+                  }
+                })
+            .build();
+
+    publisher.publish(publisher.message(), ctx -> {});
+    publisher.publish(publisher.message(), ctx -> {});
+    assertThat(parkedSync).completes();
+
+    // a single claim FLOW carries no credit of its own: both messages must drain through
+    // the consumer's ordinary per-settle credit top-up, one credit at a time
+    consumer.claimDeferred(token);
+    assertThat(redeliveredSync).completes();
+    assertThat(redelivered).hasSize(2);
+
+    consumer.close();
+  }
+
+  @Test
+  @BrokerVersionAtLeast(RABBITMQ_4_4_0)
+  void claimDeferredThrowsWhenQueueDoesNotSupportDeferralTokens() {
+    this.management.queue().name(q).classic().queue().declare();
+
+    Consumer consumer =
+        this.connection
+            .consumerBuilder()
+            .queue(q)
+            .messageHandler((context, message) -> context.accept())
+            .build();
+
+    assertThatThrownBy(() -> consumer.claimDeferred("some-token"))
+        .isInstanceOf(AmqpException.class);
+
+    consumer.close();
+  }
+
+  @Test
+  @BrokerVersionAtLeast(RABBITMQ_4_4_0)
+  void claimDeferredThrowsWhenConsumerIsClosed() {
+    this.management.queue().name(q).quorum().queue().declare();
+
+    Consumer consumer =
+        this.connection
+            .consumerBuilder()
+            .queue(q)
+            .messageHandler((context, message) -> context.accept())
+            .build();
+    consumer.close();
+
+    assertThatThrownBy(() -> consumer.claimDeferred("some-token"))
+        .isInstanceOf(AmqpException.class);
+  }
+
+  @Test
+  @BrokerVersionAtLeast(RABBITMQ_4_4_0)
+  void delayedRetryWithTokenValidatesArgumentsWithoutBreakingTheConnection() {
+    this.management.queue().name(q).quorum().queue().declare();
+
+    Publisher publisher = this.connection.publisherBuilder().queue(q).build();
+    AtomicReference<Consumer.Context> contextRef = new AtomicReference<>();
+    TestUtils.Sync deliveredSync = TestUtils.sync();
+
+    this.connection
+        .consumerBuilder()
+        .queue(q)
+        .messageHandler(
+            (context, message) -> {
+              contextRef.set(context);
+              deliveredSync.down();
+            })
+        .build();
+
+    publisher.publish(publisher.message(), ctx -> {});
+    assertThat(deliveredSync).completes();
+
+    Consumer.Context context = contextRef.get();
+    Instant future = Instant.now().plusSeconds(60);
+    Instant past = Instant.now().minusSeconds(60);
+    String oversizedToken = "a".repeat(257);
+
+    assertThatThrownBy(() -> context.delayedRetry(future, false, null))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> context.delayedRetry(future, false, ""))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> context.delayedRetry(future, false, oversizedToken))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> context.delayedRetry(past, false, "valid-token"))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    // the connection is still usable after the rejected calls above
+    context.accept();
     waitAtMost(() -> management.queueInfo(q).messageCount() == 0);
   }
 

--- a/src/test/java/com/rabbitmq/client/amqp/impl/DelayedRetryTest.java
+++ b/src/test/java/com/rabbitmq/client/amqp/impl/DelayedRetryTest.java
@@ -265,7 +265,7 @@ public class DelayedRetryTest {
             .messageHandler(
                 (context, message) -> {
                   if (deliveryCount.incrementAndGet() == 1) {
-                    context.delayedRetry(ofMillis(60_000), false, token);
+                    context.defer(token, ofMillis(60_000));
                     parkedSync.down();
                   } else {
                     messages.offer(message);
@@ -314,7 +314,7 @@ public class DelayedRetryTest {
                     batchRef.set(batch);
                     batch.add(context);
                     if (batch.size() == 2) {
-                      batch.delayedRetry(ofMillis(60_000), false, token);
+                      batch.defer(token, ofMillis(60_000));
                       parkedSync.down();
                     }
                   } else {
@@ -356,7 +356,7 @@ public class DelayedRetryTest {
             .messageHandler(
                 (context, message) -> {
                   if (deliveryCount.incrementAndGet() <= 2) {
-                    context.delayedRetry(ofMillis(60_000), false, token);
+                    context.defer(token, ofMillis(60_000));
                     parkedSync.down();
                   } else {
                     redelivered.offer(message);
@@ -441,13 +441,13 @@ public class DelayedRetryTest {
     Instant past = Instant.now().minusSeconds(60);
     String oversizedToken = "a".repeat(257);
 
-    assertThatThrownBy(() -> context.delayedRetry(future, false, null))
+    assertThatThrownBy(() -> context.defer(null, future))
         .isInstanceOf(IllegalArgumentException.class);
-    assertThatThrownBy(() -> context.delayedRetry(future, false, ""))
+    assertThatThrownBy(() -> context.defer("", future))
         .isInstanceOf(IllegalArgumentException.class);
-    assertThatThrownBy(() -> context.delayedRetry(future, false, oversizedToken))
+    assertThatThrownBy(() -> context.defer(oversizedToken, future))
         .isInstanceOf(IllegalArgumentException.class);
-    assertThatThrownBy(() -> context.delayedRetry(past, false, "valid-token"))
+    assertThatThrownBy(() -> context.defer("valid-token", past))
         .isInstanceOf(IllegalArgumentException.class);
 
     // the connection is still usable after the rejected calls above


### PR DESCRIPTION
Extend delayedRetry with a deferral token parameter and add Consumer#claimDeferred so applications can park a message with a token and pull it back explicitly ahead of its delivery time.

- add Context#delayedRetry(delay/deliveryTime, deliveryFailed, token) overloads
- add Consumer#claimDeferred(String...), throwing if the queue does not support deferral tokens
- patch the ProtonJ2 fork so FLOW frames can carry the rabbitmq:deferral-tokens property
- validate tokens client-side (UTF-8 byte length) and future delivery times

References rabbitmq/rabbitmq-server#16583